### PR TITLE
More implementation

### DIFF
--- a/scripts/deploy_rpi.sh
+++ b/scripts/deploy_rpi.sh
@@ -1,0 +1,1 @@
+rsync -av --exclude-from='.rsyncignore' ./ paddy@meshcontrol.local:~/MeshtasticBot

--- a/src/bot.py
+++ b/src/bot.py
@@ -283,3 +283,9 @@ class MeshtasticBot:
         if self.packet_counter_reset_time.date() != datetime.now().date():
             logging.info(f"Need to reset stale packet counts from {self.packet_counter_reset_time}")
             self.reset_packets_today()
+
+    def get_node_by_short_name(self, short_name: str) -> MeshNode | None:
+        for node in self.nodes.values():
+            if node.user.short_name.lower() == short_name.lower():
+                return node
+        return None

--- a/src/bot.py
+++ b/src/bot.py
@@ -81,7 +81,7 @@ class MeshtasticBot:
         sender = packet['fromId']
         to_id = packet['toId']
 
-        if to_id == '^all':
+        if to_id != self.my_id:
             return
 
         logging.info(f"Received message: '{message}' from {sender}")

--- a/src/bot.py
+++ b/src/bot.py
@@ -13,6 +13,7 @@ from src.data_classes import MeshNode, User, Position, DeviceMetrics
 from src.loggers import UserCommandLogger
 from src.persistence.node_info import AbstractNodeInfoPersistence
 from src.persistence.state import AbstractStatePersistence, AppState
+from src.tcp_interface import AutoReconnectTcpInterface
 
 
 class MeshtasticBot:
@@ -54,7 +55,7 @@ class MeshtasticBot:
         pub.subscribe(self.on_receive_text, "meshtastic.receive.text")
         pub.subscribe(self.on_node_updated, "meshtastic.node.updated")
         pub.subscribe(self.on_connection, "meshtastic.connection.established")
-        self.interface = meshtastic.tcp_interface.TCPInterface(hostname=self.address)
+        self.interface = AutoReconnectTcpInterface(hostname=self.address)
 
         logging.info("Connected. Listening for messages...")
 

--- a/src/tcp_interface.py
+++ b/src/tcp_interface.py
@@ -1,0 +1,30 @@
+import logging
+import time
+
+from meshtastic.tcp_interface import TCPInterface
+
+
+class AutoReconnectTcpInterface(TCPInterface):
+    def sendHeartbeat(self):
+        try:
+            super().sendHeartbeat()
+        except (OSError, BrokenPipeError) as e:
+            logging.error(f"Heartbeat failed: {e}")
+            self.reconnect()
+
+    def reconnect(self):
+        logging.info("Attempting to reconnect...")
+        backoff_time = 5  # Initial back-off time in seconds
+        max_backoff_time = 300  # Maximum back-off time in seconds (5 minutes)
+
+        while True:
+            try:
+                self.close()
+                time.sleep(backoff_time)
+                self.connect()
+                logging.info("Reconnected successfully")
+                break
+            except Exception as e:
+                logging.error(f"Reconnection attempt failed: {e}")
+                backoff_time = min(backoff_time * 2, max_backoff_time)  # Exponential back-off
+                logging.info(f"Next reconnection attempt in {backoff_time} seconds")


### PR DESCRIPTION
New feature:
* `!admin users (user)` command - displays a list of users who have interacted with the bot, with optional detailed view

Fixes, stability:
* try to reconnect on TCP connection drop (with back off)
* Only respond to DMs if they're addressed to self (previously, it was if they were _not_ addressed to `^all` which wasn't specific enough)

Build, CI, etc:
* Script to deploy straight to the RPi which runs the bot
