### PR TITLE
Revert "ci: allow publishing of pre-release docker images"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: Build and Push Docker Image
 
 on:
   release:
-    types: [ published, prereleased ]
+    types: [ published ]
 
 jobs:
   UnitTest:


### PR DESCRIPTION
This reverts commit 864b6a8fb7f282ca737505a945a8dca62d8870d4.