### PR TITLE
feat: run traceroute command in a separate thread to prevent blocking

### DIFF
--- a/src/ws_client.py
+++ b/src/ws_client.py
@@ -157,7 +157,18 @@ class MeshflowWSClient:
                         try:
                             target_id = int(target)
                             logger.info(f"MeshflowWSClient: received traceroute command, target={target_id}")
-                            self.on_traceroute(target_id)
+                            # Run in thread so a blocking/long-running TR doesn't block receiving
+                            # further commands (e.g. multiple TRs in quick succession, or TR that never returns)
+                            task = asyncio.create_task(asyncio.to_thread(self.on_traceroute, target_id))
+
+                            def _task_done(t):
+                                if t.cancelled():
+                                    return
+                                exc = t.exception()
+                                if exc:
+                                    logger.warning(f"MeshflowWSClient: traceroute task failed: {exc}")
+
+                            task.add_done_callback(_task_done)
                         except (TypeError, ValueError):
                             logger.warning(f"MeshflowWSClient: invalid traceroute target: {target}")
                     else:


### PR DESCRIPTION
# Summary

Run traceroute callbacks in a thread so they don't block the WebSocket receive loop. Previously, if a TR never returned or took a long time, the bot could not accept new TR commands. Now traceroute commands are dispatched via `asyncio.to_thread` and `create_task`, so the receive loop continues immediately and can handle multiple TRs in quick succession or a TR that never returns.

**Change:** `ws_client.py` – when a traceroute command is received, run `on_traceroute` in a thread pool via `asyncio.to_thread` instead of calling it directly. Add a done callback to log task failures.

No breaking changes.

## Testing performed

- Manually verified: multiple TRs in quick succession accepted without blocking; TR that never returns no longer blocks new commands
