### PR TITLE
fix: poor traceroute reliability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,8 @@ IGNORE_PORTNUMS=345,ROUTING_APP
 
 # Traceroute config
 TR_HOPS_LIMIT=5
+# Min seconds between traceroutes (firmware enforces ~30s; we rate-limit client-side)
+TR_MIN_INTERVAL_SEC=30
 
 # Max hops for text messages sent by the bot (1-7, default 5)
 TEXT_MESSAGE_MAX_HOPS=5

--- a/src/traceroute.py
+++ b/src/traceroute.py
@@ -3,14 +3,23 @@ Traceroute command handling: send traceroute requests and upload TRACEROUTE_APP 
 """
 
 import logging
+import os
+import threading
+import time
 from typing import TYPE_CHECKING
 
-import os
+from meshtastic.protobuf import mesh_pb2, portnums_pb2
 
 if TYPE_CHECKING:
     from src.bot import MeshtasticBot
 
 logger = logging.getLogger(__name__)
+
+# Firmware enforces ~30s minimum between traceroutes. We rate-limit client-side to avoid
+# sending requests the radio will reject (no ROUTING_APP packet).
+TR_MIN_INTERVAL_SEC = int(os.getenv("TR_MIN_INTERVAL_SEC", "30"))
+_last_tr_time: float = 0
+_tr_lock = threading.Lock()
 
 TR_HOPS_LIMIT = int(os.getenv("TR_HOPS_LIMIT", '5'))
 if TR_HOPS_LIMIT < 3:
@@ -32,12 +41,36 @@ def on_traceroute_command(bot: "MeshtasticBot", target_node_id: int, channel_ind
         target_node_id: Target node ID (integer, e.g. 1623194643)
         channel_index: Channel index (default 0)
     """
+    global _last_tr_time
+
     if not bot.interface or not bot.init_complete:
         logger.warning("Traceroute: bot not connected, skipping")
         return
 
+    with _tr_lock:
+        now = time.monotonic()
+        elapsed = now - _last_tr_time
+        if elapsed < TR_MIN_INTERVAL_SEC:
+            logger.info(
+                f"Traceroute: rate limited (target={target_node_id}, "
+                f"{TR_MIN_INTERVAL_SEC - int(elapsed)}s remaining)"
+            )
+            return
+        _last_tr_time = now
+
     try:
-        bot.interface.sendTraceRoute(target_node_id, TR_HOPS_LIMIT, channelIndex=channel_index)
+        # Use sendData directly instead of sendTraceRoute: sendTraceRoute blocks until response
+        # (or timeout ~2min), causing a backlog when responses are slow/lost. TR responses
+        # arrive via meshtastic.receive and are handled by bot.on_receive.
+        r = mesh_pb2.RouteDiscovery()
+        bot.interface.sendData(
+            r,
+            destinationId=target_node_id,
+            portNum=portnums_pb2.PortNum.TRACEROUTE_APP,
+            wantResponse=True,
+            channelIndex=channel_index,
+            hopLimit=TR_HOPS_LIMIT,
+        )
         logger.info(f"Traceroute: sent to target={target_node_id}")
     except Exception as e:
         logger.error(f"Traceroute: failed to send to {target_node_id}: {e}")


### PR DESCRIPTION
# Summary

Fix traceroute reliability: traceroutes were failing after the first few due to the meshtastic library's blocking `sendTraceRoute` and shared acknowledgment state. This change switches to non-blocking `sendData` and adds client-side rate limiting to match the firmware's ~30s minimum between traceroutes.

## Changes

- **Non-blocking traceroute send**: Replace `sendTraceRoute` with `sendData` directly. `sendTraceRoute` blocks until a response or timeout (~2 min), causing a backlog when responses are slow or lost. TR responses still arrive via `meshtastic.receive` and are handled by `bot.on_receive`.
- **Client-side rate limit**: Add `TR_MIN_INTERVAL_SEC` (default 30) to avoid sending requests the radio will reject. When a TR is requested within the window, log and skip instead of sending.
- **Config**: Add `TR_MIN_INTERVAL_SEC` to `.env.example`.

## Testing performed

- Manually verified traceroutes send reliably; ROUTING_APP packet observed for each outgoing TR.
- Verified rate limit: TRs within 30s are skipped with log message.
- Existing unit tests pass (`pytest test/`).
