### PR TITLE
Changed packet.decoded.emoji from boolean to int

### DIFF
--- a/src/tcp_interface.py
+++ b/src/tcp_interface.py
@@ -29,7 +29,7 @@ class SupportsMessageReactionInterface(TCPInterface):
         packet.decoded.portnum = portNum
         packet.decoded.payload = emoji_bytes
         packet.decoded.reply_id = messageId
-        packet.decoded.emoji = True
+        packet.decoded.emoji = 1
 
         self._sendPacket(packet, destinationId,
                          wantAck=wantAck,


### PR DESCRIPTION
# Summary

Tied to #64.

When using the `!ping` command on `meshtastic-bot` 0.3.2, the software log were producing errors and no response was triggered. 

```
meshtastic-bot  | 2026-03-18 09:08:59,797 - [ERROR] bot.handle_private_message - Error handling message: Field meshtastic.protobuf.Data.emoji: Expected an int, got a boolean.
```

## Testing performed

After applying the change, the error is no longer encountered, though messages aren't being sent, which is raised under #63 for investigation.

I've tested this from two different nodes to the node associated with `meshtastic-bot` and haven't been able to recreate the error.

```
meshtastic-bot  | 2026-03-19 11:41:04,159 - [INFO] bot.handle_private_message - Received private message: '!ping' from Plai 2afc
meshtastic-bot  | 2026-03-19 11:41:04,237 - [INFO] bot.on_receive - Skipping API submission for packet with portnum ROUTING_APP (in IGNORE_PORTNUMS)
meshtastic-bot  | 2026-03-19 11:41:04,337 - [INFO] bot.on_receive - Skipping API submission for packet with portnum ROUTING_APP (in IGNORE_PORTNUMS)
```