### PR TITLE
fix: handle None last-heard timestamps when sorting nodes

### DIFF
--- a/src/commands/nodes.py
+++ b/src/commands/nodes.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 from meshtastic.protobuf.mesh_pb2 import MeshPacket
 
 from src.bot import MeshtasticBot
@@ -24,8 +26,13 @@ class NodesCommand(AbstractCommandWithSubcommands):
         online_nodes = self.bot.node_info.get_online_nodes()
         offline_nodes = self.bot.node_info.get_offline_nodes()
 
-        # get nodes sorted by last_head
-        sorted_nodes = sorted(nodes, key=lambda n: self.bot.node_info.get_last_heard(n.id), reverse=True)
+        # get nodes sorted by last_heard (most recent first)
+        # Nodes we've never heard from yet have last_heard=None, so treat them as very old.
+        sorted_nodes = sorted(
+            nodes,
+            key=lambda n: self.bot.node_info.get_last_heard(n.id) or datetime.min.replace(tzinfo=timezone.utc),
+            reverse=True,
+        )
         response = f"{len(online_nodes)} nodes online, {len(offline_nodes)} offline."
 
         # Add up to 10 nodes with the most packets received today

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -3,7 +3,10 @@ import urllib.parse
 from datetime import datetime, timezone
 
 
-def pretty_print_last_heard(last_heard_timestamp: int | datetime) -> str:
+def pretty_print_last_heard(last_heard_timestamp: int | datetime | None) -> str:
+    if last_heard_timestamp is None:
+        return "never"
+
     if not isinstance(last_heard_timestamp, datetime):
         last_heard = datetime.fromtimestamp(last_heard_timestamp, timezone.utc)
     else:


### PR DESCRIPTION
# Summary

**Note**: Claude was used to produce this fix, so caution warranted.

Fixed a crash when sorting nodes that have never been heard from (#65 ). `get_last_heard()` returns `None` for such nodes, which caused a `TypeError ('<' not supported between instances of 'NoneType' and 'datetime.datetime')` in the `sorted()` call.

- `nodes.py`: Updated sort key to fall back to `datetime.min` (UTC) when `get_last_heard()` returns `None`, so never-heard nodes sort to the end of the list rather than crashing.

- `helpers.py`:  Updated `pretty_print_last_heard` to accept `None` as a valid input, returning `"never"` in that case.

# Testing performed

Manually verified the error no longer occurs by reviewing the log output after the fix, confirmed no other errors were appearing and that the command was followed through to completion, being received by the node issuing the `!nodes` command.

Ran full meshtastic-bot test suite: 100 passed