### PR TITLE
refactor(bot): drop pandas dependency

### DIFF
--- a/.cursor/skills/meshflow-git-workflow/SKILL.md
+++ b/.cursor/skills/meshflow-git-workflow/SKILL.md
@@ -116,7 +116,7 @@ refactor(storage): extract packet parsing into service
 
 When the work is done:
 
-1. Open a PR in each affected repository
+1. Open a PR in each affected repository using the github-personal MCP. Do not use gh cli.
 2. Link the relevant issue(s) in the PR (e.g. "Closes #123")
 3. For multi-repo changes, link related PRs between repos in the description
 

--- a/.cursor/skills/meshflow-git-workflow/SKILL.md
+++ b/.cursor/skills/meshflow-git-workflow/SKILL.md
@@ -13,6 +13,20 @@ description: >-
 
 When working on a feature across meshflow-api, meshtastic-bot, or meshtastic-bot-ui, follow this workflow: plan → issue → branch → commit → PR.
 
+Use the `github-personal` MCP for all MeshFlow work.
+
+We start by documenting and refining a plan collaboratively. After agreeing upon the plan, create tickets in applicable repositories. If necessary add a parent ticket and create linked children. Add the plan to the single or parent ticket, and exerpts of the plan to any children. Update the plan with links to any relevant tickets.
+
+It's also possible that we start with a lightweight ticket (i.e. a feature request from a user), then generate the plan. In that situation, the ticket should be updated with full details from the plan, instead of creating a new one
+
+When executing the plan:
+
+1. Create our git branches from origin/main
+2. Do the work
+3. Commit as appropriate
+4. Push and open a pull request for applicable repositories. Link relevant tickets.
+5. Done
+
 ---
 
 ## 1. Planning and Issues
@@ -25,13 +39,15 @@ When working on a feature across meshflow-api, meshtastic-bot, or meshtastic-bot
 
 ## 2. Branch Naming
 
-Format: `{repo-prefix}-{issue-number}/{author}/{short-description}`
+Format: `{issue-repo-prefix}-{issue-number}/{author}/{short-description}`
 
-| Repo | Prefix | Example |
-|------|--------|---------|
-| meshflow-api | `api` | `api-456/paddy/fix-endpoint-bug` |
-| meshtastic-bot | `bot` | `bot-123/paddy/add-traceroute-command` |
-| meshtastic-bot-ui | `ui` | `ui-78/paddy/add-cool-new-page` |
+**Which prefix?** Use the prefix for the **GitHub repository where the tracking issue lives**, not the repo you are committing in. That keeps one issue number traceable across Meshflow repos.
+
+| Issue filed in | Prefix | Use that prefix in every repo that has a branch for the work |
+|----------------|--------|----------------------------------------------------------------|
+| meshtastic-bot-ui | `ui` | e.g. UI #136 → `ui-136/paddy/...` in **both** meshtastic-bot-ui **and** meshflow-api (and meshtastic-bot if needed) |
+| meshflow-api | `api` | e.g. API #456 → `api-456/paddy/...` in every affected repo |
+| meshtastic-bot | `bot` | e.g. bot #123 → `bot-123/paddy/...` in every affected repo |
 
 Use kebab-case for the description. Keep it short.
 
@@ -113,7 +129,7 @@ When the work is done:
 | Step | Action |
 |------|--------|
 | Plan | Issue in relevant repo(s); parent in meshflow-api if multi-repo |
-| Branch | `{prefix}-{num}/{author}/{description}` |
+| Branch | `{issue-repo-prefix}-{num}/{author}/{description}` (prefix = repo where the issue lives) |
 | Pre-commit | meshflow-api/meshtastic-bot: venv + black, isort, flake8; meshtastic-bot-ui: `npm run format` |
 | Commit | Conventional commits, no "enhance" |
 | PR | Open in all affected repos, link issues and related PRs |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,3 +103,8 @@ Environment variables (see `.env.example`):
 
 When asked to create a pull request description, follow the template at
 .github/pull_request_template.md, and output a markdown file named `tmp/PR.md`
+
+## Plan mode
+
+When creating a plan, Include that we should branch from the latest origin/main, do the work, commit, push, and open a PR. Use the github-personal MCP. the gh
+command is not available, do not use it.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ Pypubsub~=4.0.3
 jinja2~=3.1.6
 schedule~=1.2.2
 python-dotenv~=1.0.1
-pandas~=2.2.3
 typing_extensions~=4.12.2
 requests~=2.32.3
 

--- a/src/commands/admin.py
+++ b/src/commands/admin.py
@@ -1,10 +1,16 @@
+from collections import Counter
 from datetime import datetime, timezone, timedelta
+from typing import Any
 
 from meshtastic.protobuf.mesh_pb2 import MeshPacket
 
 from src.bot import MeshtasticBot
 from src.commands.command import AbstractCommandWithSubcommands
 from src.data_classes import MeshNode
+
+
+def _rows_for_sender(rows: list[dict[str, Any]], sender_id: str) -> list[dict[str, Any]]:
+    return [r for r in rows if r['sender_id'] == sender_id]
 
 
 class AdminCommand(AbstractCommandWithSubcommands):
@@ -66,11 +72,11 @@ class AdminCommand(AbstractCommandWithSubcommands):
         responder_history = self.bot.command_logger.get_responder_history(
             since=since, sender_id=req_user.id)
 
-        command_counts = command_history['base_command'].value_counts().to_dict()
-        responder_counts = responder_history['responder_class'].value_counts().to_dict()
+        command_counts = Counter(row['base_command'] for row in command_history)
+        responder_counts = Counter(row['responder_class'] for row in responder_history)
 
         known_count = sum(command_counts.values())
-        unknown_count = unknown_command_history.shape[0]
+        unknown_count = len(unknown_command_history)
         responder_count = sum(responder_counts.values())
 
         response = f"{req_user.long_name} - {known_count} cmds, {responder_count} responders, {unknown_count} unknown cmds\n"
@@ -79,19 +85,19 @@ class AdminCommand(AbstractCommandWithSubcommands):
 
         if known_count > 0:
             response = f"Commands:\n"
-            for command, count in command_counts.items():
+            for command, count in command_counts.most_common():
                 response += f"- {command}: {count}\n"
             self.reply(packet, response)
 
         if unknown_count > 0:
             response = "Unknown Commands:\n"
-            for _, row in unknown_command_history.iterrows():
+            for row in unknown_command_history:
                 response += f"- {row['message']}\n"
             self.reply(packet, response)
 
         if responder_count > 0:
             response = f"Responders:\n"
-            for responder, count in responder_counts.items():
+            for responder, count in responder_counts.most_common():
                 response += f"- {responder}: {count}\n"
             self.reply(packet, response)
 
@@ -104,15 +110,15 @@ class AdminCommand(AbstractCommandWithSubcommands):
         unknown_command_history = self.bot.command_logger.get_unknown_command_history(since=since)
         responder_history = self.bot.command_logger.get_responder_history(since=since)
 
-        user_ids = (set(command_history['sender_id'])
-                    .union(set(unknown_command_history['sender_id']))
-                    .union(set(responder_history['sender_id'])))
+        user_ids = ({r['sender_id'] for r in command_history}
+                    | {r['sender_id'] for r in unknown_command_history}
+                    | {r['sender_id'] for r in responder_history})
 
         # sort user_ids by sum of known, unknown, and responder commands. finally, sort by user_id
         user_ids = sorted(user_ids, key=lambda user_id: (
-            command_history[command_history['sender_id'] == user_id].shape[0]
-            + unknown_command_history[unknown_command_history['sender_id'] == user_id].shape[0]
-            + responder_history[responder_history['sender_id'] == user_id].shape[0],
+            len(_rows_for_sender(command_history, user_id))
+            + len(_rows_for_sender(unknown_command_history, user_id))
+            + len(_rows_for_sender(responder_history, user_id)),
             user_id
         ))
 
@@ -121,13 +127,13 @@ class AdminCommand(AbstractCommandWithSubcommands):
             node = self.bot.node_db.get_by_id(user_id)
             user_name = node.short_name if node else f"Unknown user {user_id}"
 
-            known_requests = command_history[command_history['sender_id'] == user_id]
-            unknown_requests = unknown_command_history[unknown_command_history['sender_id'] == user_id]
-            responder_requests = responder_history[responder_history['sender_id'] == user_id]
+            known_requests = _rows_for_sender(command_history, user_id)
+            unknown_requests = _rows_for_sender(unknown_command_history, user_id)
+            responder_requests = _rows_for_sender(responder_history, user_id)
 
-            known_request_count = known_requests.shape[0]
-            unknown_request_count = unknown_requests.shape[0]
-            responder_request_count = responder_requests.shape[0]
+            known_request_count = len(known_requests)
+            unknown_request_count = len(unknown_requests)
+            responder_request_count = len(responder_requests)
             # total_requests = known_request_count + unknown_request_count + responder_request_count
 
             response += f"- {user_name}: {known_request_count} cmds, {unknown_request_count} unk, {responder_request_count} resp\n"

--- a/src/persistence/commands_logger.py
+++ b/src/persistence/commands_logger.py
@@ -1,10 +1,13 @@
 import abc
 import sqlite3
 from datetime import datetime, timezone
-
-import pandas as pd
+from typing import Any
 
 from src.persistence import BaseSqlitePersistenceStore
+
+
+def _sqlite_rows_to_dicts(rows: list[tuple], columns: list[str]) -> list[dict[str, Any]]:
+    return [dict(zip(columns, row)) for row in rows]
 
 
 class AbstractCommandLogger(abc.ABC):
@@ -22,15 +25,15 @@ class AbstractCommandLogger(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def get_command_history(self, since: datetime, sender_id: str = None) -> pd.DataFrame:
+    def get_command_history(self, since: datetime, sender_id: str = None) -> list[dict[str, Any]]:
         pass
 
     @abc.abstractmethod
-    def get_unknown_command_history(self, since: datetime, sender_id: str = None) -> pd.DataFrame:
+    def get_unknown_command_history(self, since: datetime, sender_id: str = None) -> list[dict[str, Any]]:
         pass
 
     @abc.abstractmethod
-    def get_responder_history(self, since: datetime, sender_id: str = None) -> pd.DataFrame:
+    def get_responder_history(self, since: datetime, sender_id: str = None) -> list[dict[str, Any]]:
         pass
 
 
@@ -97,7 +100,8 @@ class SqliteCommandLogger(AbstractCommandLogger, BaseSqlitePersistenceStore):
             ''', (sender_id, message, datetime.now(timezone.utc).isoformat()))
             conn.commit()
 
-    def get_command_history(self, since: datetime, sender_id: str = None) -> pd.DataFrame:
+    def get_command_history(self, since: datetime, sender_id: str = None) -> list[dict[str, Any]]:
+        columns = ['sender_id', 'base_command', 'timestamp']
         with sqlite3.connect(self.db_path) as conn:
             cursor = conn.cursor()
             if sender_id:
@@ -111,9 +115,10 @@ class SqliteCommandLogger(AbstractCommandLogger, BaseSqlitePersistenceStore):
                     WHERE timestamp >= ?
                 ''', (since.isoformat(),))
             rows = cursor.fetchall()
-            return pd.DataFrame(rows, columns=['sender_id', 'base_command', 'timestamp'])
+            return _sqlite_rows_to_dicts(rows, columns)
 
-    def get_unknown_command_history(self, since: datetime, sender_id: str = None) -> pd.DataFrame:
+    def get_unknown_command_history(self, since: datetime, sender_id: str = None) -> list[dict[str, Any]]:
+        columns = ['sender_id', 'message', 'timestamp']
         with sqlite3.connect(self.db_path) as conn:
             cursor = conn.cursor()
             if sender_id:
@@ -127,9 +132,10 @@ class SqliteCommandLogger(AbstractCommandLogger, BaseSqlitePersistenceStore):
                     WHERE timestamp >= ?
                 ''', (since.isoformat(),))
             rows = cursor.fetchall()
-            return pd.DataFrame(rows, columns=['sender_id', 'message', 'timestamp'])
+            return _sqlite_rows_to_dicts(rows, columns)
 
-    def get_responder_history(self, since: datetime, sender_id: str = None) -> pd.DataFrame:
+    def get_responder_history(self, since: datetime, sender_id: str = None) -> list[dict[str, Any]]:
+        columns = ['sender_id', 'responder_class', 'timestamp']
         with sqlite3.connect(self.db_path) as conn:
             cursor = conn.cursor()
             if sender_id:
@@ -143,5 +149,4 @@ class SqliteCommandLogger(AbstractCommandLogger, BaseSqlitePersistenceStore):
                     WHERE timestamp >= ?
                 ''', (since.isoformat(),))
             rows = cursor.fetchall()
-            return pd.DataFrame(rows, columns=['sender_id', 'responder_class', 'timestamp'])
-
+            return _sqlite_rows_to_dicts(rows, columns)

--- a/test/commands/test_admin.py
+++ b/test/commands/test_admin.py
@@ -2,8 +2,6 @@ from datetime import datetime, timedelta, timezone
 import unittest
 from unittest.mock import MagicMock
 
-import pandas as pd
-
 from src.commands.admin import AdminCommand
 from src.data_classes import MeshNode
 from test.commands import CommandWSCTestCase
@@ -24,23 +22,35 @@ class TestAdminCommand(CommandWSCTestCase):
     def _setup_nodes_mock_data(self, node_list: list[MeshNode]):
         # Create mock command history using test nodes
         # each test_node gets 2 commands, 1 unknown command, and 2 responders
-        self.mock_command_history = pd.DataFrame({
-            'sender_id': [node.user.id for node in node_list for _ in range(2)],
-            'base_command': ['cmd1', 'cmd2'] * len(node_list),
-            'timestamp': [datetime.now(timezone.utc) - timedelta(days=i) for i in range(2 * len(node_list))]
-        })
+        unknown_messages = ['unknown1', 'unknown2', 'unknown3']
+        self.mock_command_history = [
+            {
+                'sender_id': node.user.id,
+                'base_command': 'cmd1' if j == 0 else 'cmd2',
+                'timestamp': datetime.now(timezone.utc) - timedelta(days=i * 2 + j),
+            }
+            for i, node in enumerate(node_list)
+            for j in range(2)
+        ]
 
-        self.mock_unknown_command_history = pd.DataFrame({
-            'sender_id': [node.user.id for node in node_list],
-            'message': ['unknown1', 'unknown2', 'unknown3'][:len(node_list)],
-            'timestamp': [datetime.now(timezone.utc) - timedelta(days=i) for i in range(len(node_list))]
-        })
+        self.mock_unknown_command_history = [
+            {
+                'sender_id': node.user.id,
+                'message': unknown_messages[i],
+                'timestamp': datetime.now(timezone.utc) - timedelta(days=i),
+            }
+            for i, node in enumerate(node_list)
+        ]
 
-        self.mock_responder_history = pd.DataFrame({
-            'sender_id': [node.user.id for node in node_list for _ in range(2)],
-            'responder_class': ['Responder1', 'Responder2'] * len(node_list),
-            'timestamp': [datetime.now(timezone.utc) - timedelta(days=i) for i in range(2 * len(node_list))]
-        })
+        self.mock_responder_history = [
+            {
+                'sender_id': node.user.id,
+                'responder_class': 'Responder1' if j == 0 else 'Responder2',
+                'timestamp': datetime.now(timezone.utc) - timedelta(days=i * 2 + j),
+            }
+            for i, node in enumerate(node_list)
+            for j in range(2)
+        ]
 
         self.bot.command_logger.get_command_history = MagicMock(return_value=self.mock_command_history)
         self.bot.command_logger.get_unknown_command_history = MagicMock(return_value=self.mock_unknown_command_history)

--- a/test/persistence/test_commands_logger.py
+++ b/test/persistence/test_commands_logger.py
@@ -72,20 +72,18 @@ class TestSqliteCommandLogger(unittest.TestCase):
 
         since = datetime.now(timezone.utc) - timedelta(days=1)
         history = self.logger.get_command_history(since=since)
-        self.assertFalse(history.empty)
-        self.assertIn('sender_id', history.columns)
-        self.assertIn('base_command', history.columns)
-        self.assertIn('timestamp', history.columns)
+        self.assertGreater(len(history), 0)
+        for key in ('sender_id', 'base_command', 'timestamp'):
+            self.assertIn(key, history[0])
 
     def test_get_unknown_command_history(self):
         self.logger.log_unknown_request('sender1', 'unknown message')
 
         since = datetime.now(timezone.utc) - timedelta(days=1)
         history = self.logger.get_unknown_command_history(since=since)
-        self.assertFalse(history.empty)
-        self.assertIn('sender_id', history.columns)
-        self.assertIn('message', history.columns)
-        self.assertIn('timestamp', history.columns)
+        self.assertGreater(len(history), 0)
+        for key in ('sender_id', 'message', 'timestamp'):
+            self.assertIn(key, history[0])
 
     def test_get_responder_history(self):
         responder_instance = MagicMock(spec=AbstractResponder)
@@ -93,10 +91,9 @@ class TestSqliteCommandLogger(unittest.TestCase):
 
         since = datetime.now(timezone.utc) - timedelta(days=1)
         history = self.logger.get_responder_history(since=since)
-        self.assertFalse(history.empty)
-        self.assertIn('sender_id', history.columns)
-        self.assertIn('responder_class', history.columns)
-        self.assertIn('timestamp', history.columns)
+        self.assertGreater(len(history), 0)
+        for key in ('sender_id', 'responder_class', 'timestamp'):
+            self.assertIn(key, history[0])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Summary

Removes the **pandas** dependency so the bot installs cleanly on memory- and wheel-constrained devices (e.g. Raspberry Pi Zero W / ARMv6) without pulling numpy.

- `SqliteCommandLogger` now returns `list[dict[str, Any]]` for command / unknown / responder history instead of `pd.DataFrame`.
- `AdminCommand` uses `collections.Counter` and list comprehensions for `!admin users` summaries.

Closes #70.

## Testing performed

- `venv/bin/python -m pytest test/ --doctest-modules` (100 passed, 2 skipped)
