### PR TITLE
fix: Fix "too many open files" resource exhaustion

### DIFF
--- a/src/api/BaseAPIWrapper.py
+++ b/src/api/BaseAPIWrapper.py
@@ -6,10 +6,12 @@ import requests
 class BaseAPIWrapper(ABC):
     base_url: str
     auth_token: str | None
+    session: requests.Session
 
     def __init__(self, base_url: str, auth_token: str = None):
         self.base_url = base_url.rstrip('/')
         self.auth_token = auth_token
+        self.session = requests.Session()
 
     def _get_headers(self) -> dict:
         headers = {
@@ -23,13 +25,13 @@ class BaseAPIWrapper(ABC):
 
     def _get(self, url: str) -> requests.Response:
         full_url = f"{self.base_url}/{url.lstrip('/')}"
-        response = requests.get(full_url, headers=self._get_headers())
+        response = self.session.get(full_url, headers=self._get_headers())
         response.raise_for_status()
 
         return response
 
     def _post(self, url: str, json: dict) -> requests.Response:
         full_url = f"{self.base_url}/{url.lstrip('/')}"
-        response = requests.post(full_url, json=json, headers=self._get_headers())
+        response = self.session.post(full_url, json=json, headers=self._get_headers())
         response.raise_for_status()
         return response

--- a/src/api/StorageAPI.py
+++ b/src/api/StorageAPI.py
@@ -134,7 +134,7 @@ class StorageAPIWrapper(BaseAPIWrapper):
         else:
             return None
 
-    def _dump_failed_packet(self, packet, ex: HTTPError):
+    def _dump_failed_packet(self, packet, ex: Exception):
         raw_packet: MeshPacket = packet.get('raw', None)
 
         timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
@@ -144,13 +144,21 @@ class StorageAPIWrapper(BaseAPIWrapper):
 
         try:
             error_info = {
-                'status_code': ex.response.status_code,
-                'reason': ex.response.reason,
-                'text': ex.response.text,
-                'url': ex.response.url,
-                'headers': dict(ex.response.headers),
                 'traceback': traceback.format_exc()
             }
+            # Only add response details if the exception has a response object (HTTPError)
+            if hasattr(ex, 'response') and ex.response is not None:
+                error_info.update({
+                    'status_code': ex.response.status_code,
+                    'reason': ex.response.reason,
+                    'text': ex.response.text,
+                    'url': ex.response.url,
+                    'headers': dict(ex.response.headers),
+                })
+            else:
+                # For non-HTTP errors, just include the error message
+                error_info['error'] = str(ex)
+            
             filename = f"failed_packet_{timestamp}_error.json"
             filepath = self.failed_packets_dir / filename
             with open(filepath, 'w') as f:

--- a/src/persistence/__init__.py
+++ b/src/persistence/__init__.py
@@ -1,19 +1,57 @@
 import abc
 import logging
+import sqlite3
+import threading
 from pathlib import Path
 
 
 class BaseSqlitePersistenceStore(abc.ABC):
     db_path: Path
+    _conn: sqlite3.Connection | None
+    _lock: threading.RLock
 
     def __init__(self, db_path: str):
         self.db_path = Path(db_path)
+        self._conn = None
+        self._lock = threading.RLock()
         self._initialize_db()
         if self.db_path.is_relative_to(Path.cwd()):
             path_string = self.db_path.relative_to(Path.cwd())
         else:
             path_string = self.db_path
         logging.info(f"Connected to {self.__class__.__name__} DB at {path_string}")
+
+    def _get_connection(self) -> sqlite3.Connection:
+        """Get or create a persistent database connection."""
+        if self._conn is None:
+            # Ensure parent directory exists
+            self.db_path.parent.mkdir(parents=True, exist_ok=True)
+            
+            self._conn = sqlite3.connect(
+                str(self.db_path),
+                check_same_thread=False,
+                timeout=10.0
+            )
+            # Enable WAL mode for better concurrency
+            try:
+                cursor = self._conn.cursor()
+                cursor.execute("PRAGMA journal_mode=WAL")
+                cursor.close()
+            except Exception:
+                # WAL mode is optional, continue without it if it fails
+                pass
+        else:
+            # Validate existing connection is still viable
+            try:
+                cursor = self._conn.cursor()
+                cursor.execute("SELECT 1")
+                cursor.close()
+            except sqlite3.ProgrammingError:
+                # Connection is broken, reset it
+                self._conn = None
+                return self._get_connection()  # Recursive call to create a new one
+        
+        return self._conn
 
     @abc.abstractmethod
     def _initialize_db(self):

--- a/src/persistence/commands_logger.py
+++ b/src/persistence/commands_logger.py
@@ -37,7 +37,8 @@ class AbstractCommandLogger(abc.ABC):
 class SqliteCommandLogger(AbstractCommandLogger, BaseSqlitePersistenceStore):
 
     def _initialize_db(self):
-        with sqlite3.connect(self.db_path) as conn:
+        conn = self._get_connection()
+        with self._lock:
             cursor = conn.cursor()
             cursor.execute('''
                 CREATE TABLE IF NOT EXISTS command_log (
@@ -70,7 +71,8 @@ class SqliteCommandLogger(AbstractCommandLogger, BaseSqlitePersistenceStore):
         base_cmd, subcommands, args = command_instance.get_command_for_logging(message)
         subcommands_str = ' '.join(subcommands) if subcommands else None
 
-        with sqlite3.connect(self.db_path) as conn:
+        conn = self._get_connection()
+        with self._lock:
             cursor = conn.cursor()
             cursor.execute('''
                 INSERT INTO command_log (sender_id, base_command, sub_commands, args, timestamp, handler_class)
@@ -80,7 +82,8 @@ class SqliteCommandLogger(AbstractCommandLogger, BaseSqlitePersistenceStore):
             conn.commit()
 
     def log_responder_handled(self, sender_id: str, responder_instance, message_text: str) -> None:
-        with sqlite3.connect(self.db_path) as conn:
+        conn = self._get_connection()
+        with self._lock:
             cursor = conn.cursor()
             cursor.execute('''
                 INSERT INTO responder_log (sender_id, message, timestamp, responder_class)
@@ -89,7 +92,8 @@ class SqliteCommandLogger(AbstractCommandLogger, BaseSqlitePersistenceStore):
             conn.commit()
 
     def log_unknown_request(self, sender_id: str, message: str) -> None:
-        with sqlite3.connect(self.db_path) as conn:
+        conn = self._get_connection()
+        with self._lock:
             cursor = conn.cursor()
             cursor.execute('''
                 INSERT INTO unknown_requests (sender_id, message, timestamp)
@@ -98,7 +102,8 @@ class SqliteCommandLogger(AbstractCommandLogger, BaseSqlitePersistenceStore):
             conn.commit()
 
     def get_command_history(self, since: datetime, sender_id: str = None) -> pd.DataFrame:
-        with sqlite3.connect(self.db_path) as conn:
+        conn = self._get_connection()
+        with self._lock:
             cursor = conn.cursor()
             if sender_id:
                 cursor.execute('''
@@ -114,7 +119,8 @@ class SqliteCommandLogger(AbstractCommandLogger, BaseSqlitePersistenceStore):
             return pd.DataFrame(rows, columns=['sender_id', 'base_command', 'timestamp'])
 
     def get_unknown_command_history(self, since: datetime, sender_id: str = None) -> pd.DataFrame:
-        with sqlite3.connect(self.db_path) as conn:
+        conn = self._get_connection()
+        with self._lock:
             cursor = conn.cursor()
             if sender_id:
                 cursor.execute('''
@@ -130,7 +136,8 @@ class SqliteCommandLogger(AbstractCommandLogger, BaseSqlitePersistenceStore):
             return pd.DataFrame(rows, columns=['sender_id', 'message', 'timestamp'])
 
     def get_responder_history(self, since: datetime, sender_id: str = None) -> pd.DataFrame:
-        with sqlite3.connect(self.db_path) as conn:
+        conn = self._get_connection()
+        with self._lock:
             cursor = conn.cursor()
             if sender_id:
                 cursor.execute('''

--- a/src/persistence/node_db.py
+++ b/src/persistence/node_db.py
@@ -117,7 +117,8 @@ class InMemoryNodeDB(AbstractNodeDB):
 class SqliteNodeDB(BaseSqlitePersistenceStore, AbstractNodeDB):
 
     def _initialize_db(self):
-        with sqlite3.connect(self.db_path) as conn:
+        conn = self._get_connection()
+        with self._lock:
             cursor = conn.cursor()
             cursor.execute('''
                 CREATE TABLE IF NOT EXISTS nodes (
@@ -156,7 +157,8 @@ class SqliteNodeDB(BaseSqlitePersistenceStore, AbstractNodeDB):
             conn.commit()
 
     def store_user(self, node_user: MeshNode.User):
-        with sqlite3.connect(self.db_path) as conn:
+        conn = self._get_connection()
+        with self._lock:
             cursor = conn.cursor()
             cursor.execute('''
                 INSERT OR REPLACE INTO nodes (id, short_name, long_name, macaddr, hw_model, public_key)
@@ -166,7 +168,8 @@ class SqliteNodeDB(BaseSqlitePersistenceStore, AbstractNodeDB):
             conn.commit()
 
     def store_position(self, node_id: str, position: MeshNode.Position):
-        with sqlite3.connect(self.db_path) as conn:
+        conn = self._get_connection()
+        with self._lock:
             cursor = conn.cursor()
             cursor.execute('''
                 INSERT INTO positions (node_id, logged_time, reported_time, latitude, longitude, altitude, location_source)
@@ -176,7 +179,8 @@ class SqliteNodeDB(BaseSqlitePersistenceStore, AbstractNodeDB):
             conn.commit()
 
     def store_device_metrics(self, node_id: str, device_metrics: MeshNode.DeviceMetrics):
-        with sqlite3.connect(self.db_path) as conn:
+        conn = self._get_connection()
+        with self._lock:
             cursor = conn.cursor()
             cursor.execute('''
                 INSERT INTO device_metrics (node_id, logged_time, battery_level, voltage, channel_utilization, air_util_tx, uptime_seconds)
@@ -186,7 +190,8 @@ class SqliteNodeDB(BaseSqlitePersistenceStore, AbstractNodeDB):
             conn.commit()
 
     def get_by_id(self, node_id: str) -> MeshNode.User | None:
-        with sqlite3.connect(self.db_path) as conn:
+        conn = self._get_connection()
+        with self._lock:
             cursor = conn.cursor()
             cursor.execute('SELECT id, short_name, long_name, macaddr, hw_model, public_key FROM nodes WHERE id = ?',
                            (node_id,))
@@ -197,7 +202,8 @@ class SqliteNodeDB(BaseSqlitePersistenceStore, AbstractNodeDB):
             return None
 
     def get_by_short_name(self, short_name: str) -> MeshNode.User | None:
-        with sqlite3.connect(self.db_path) as conn:
+        conn = self._get_connection()
+        with self._lock:
             cursor = conn.cursor()
             cursor.execute(
                 'SELECT id, short_name, long_name, macaddr, hw_model, public_key FROM nodes WHERE short_name = ? COLLATE NOCASE',
@@ -209,7 +215,8 @@ class SqliteNodeDB(BaseSqlitePersistenceStore, AbstractNodeDB):
             return None
 
     def list_nodes(self) -> list[MeshNode.User]:
-        with sqlite3.connect(self.db_path) as conn:
+        conn = self._get_connection()
+        with self._lock:
             cursor = conn.cursor()
             cursor.execute('SELECT id, short_name, long_name, macaddr, hw_model, public_key FROM nodes')
             rows = cursor.fetchall()
@@ -217,7 +224,8 @@ class SqliteNodeDB(BaseSqlitePersistenceStore, AbstractNodeDB):
                                   hw_model=row[4], public_key=row[5]) for row in rows]
 
     def get_last_position(self, node_id: str) -> MeshNode.Position | None:
-        with sqlite3.connect(self.db_path) as conn:
+        conn = self._get_connection()
+        with self._lock:
             cursor = conn.cursor()
             cursor.execute('''
                 SELECT logged_time, reported_time, latitude, longitude, altitude, location_source
@@ -234,7 +242,8 @@ class SqliteNodeDB(BaseSqlitePersistenceStore, AbstractNodeDB):
 
     def get_position_log(self, node_id: str, start: datetime, end: datetime) -> list[
         MeshNode.Position]:
-        with sqlite3.connect(self.db_path) as conn:
+        conn = self._get_connection()
+        with self._lock:
             cursor = conn.cursor()
             cursor.execute('''
                 SELECT logged_time, reported_time, latitude, longitude, altitude, location_source
@@ -247,7 +256,8 @@ class SqliteNodeDB(BaseSqlitePersistenceStore, AbstractNodeDB):
                                       altitude=row[4], location_source=row[5]) for row in rows]
 
     def get_last_device_metrics(self, node_id: str) -> MeshNode.DeviceMetrics | None:
-        with sqlite3.connect(self.db_path) as conn:
+        conn = self._get_connection()
+        with self._lock:
             cursor = conn.cursor()
             cursor.execute('''
                 SELECT logged_time, battery_level, voltage, channel_utilization, air_util_tx, uptime_seconds
@@ -264,7 +274,8 @@ class SqliteNodeDB(BaseSqlitePersistenceStore, AbstractNodeDB):
 
     def get_device_metrics_log(self, node_id: str, start: datetime, end: datetime) -> list[
         MeshNode.DeviceMetrics]:
-        with sqlite3.connect(self.db_path) as conn:
+        conn = self._get_connection()
+        with self._lock:
             cursor = conn.cursor()
             cursor.execute('''
                 SELECT logged_time, battery_level, voltage, channel_utilization, air_util_tx, uptime_seconds

--- a/src/persistence/user_prefs.py
+++ b/src/persistence/user_prefs.py
@@ -51,7 +51,8 @@ class AbstractUserPrefsPersistence(abc.ABC):
 class SqliteUserPrefsPersistence(AbstractUserPrefsPersistence, BaseSqlitePersistenceStore):
 
     def _initialize_db(self):
-        with sqlite3.connect(self.db_path) as conn:
+        conn = self._get_connection()
+        with self._lock:
             cursor = conn.cursor()
             cursor.execute('''
                 CREATE TABLE IF NOT EXISTS user_prefs (
@@ -66,7 +67,8 @@ class SqliteUserPrefsPersistence(AbstractUserPrefsPersistence, BaseSqlitePersist
             conn.commit()
 
     def get_user_prefs(self, user_id: str) -> UserPrefs:
-        with sqlite3.connect(self.db_path) as conn:
+        conn = self._get_connection()
+        with self._lock:
             # Fetch the data
             cursor = conn.cursor()
             cursor.execute('''
@@ -91,7 +93,8 @@ class SqliteUserPrefsPersistence(AbstractUserPrefsPersistence, BaseSqlitePersist
             return user_prefs
 
     def persist_user_prefs(self, user_id: str, user_prefs: UserPrefs) -> UserPrefs:
-        with sqlite3.connect(self.db_path) as conn:
+        conn = self._get_connection()
+        with self._lock:
             cursor = conn.cursor()
             for key, preference in user_prefs.__dict__.items():
                 if key == 'user_id':


### PR DESCRIPTION
**Warning**: This was implemented by Claude after some prompting. I only ran the test suite afterwards and confirmed the performance within the container itself after running for some time to try and catch any errors. 

# Summary

Fix comprehensive file descriptor resource exhaustion and cascading failures in packet storage and database access, experienced in #74.

The bot was exhausting file descriptors due to:
1. **HTTP connections** not being properly managed in `BaseAPIWrapper`
2. **SQLite connections** being created for every single database operation in persistence layers

This caused cascading failures:
- SSL/connection errors when attempting to store packets in Meshflow API
- SQLite database errors when the system runs out of file descriptors
- Failed packet dump failures due to resource exhaustion
- Inability to read node data during packet processing

## Root Causes & Fixes

### 1. HTTP Connection Pooling
**Problem**: `BaseAPIWrapper` used `requests.get()` and `requests.post()` directly, creating a new connection for each request without connection pooling.

**Fix**: Use `requests.Session()` for connection reuse and proper resource management (handles connection pooling automatically).

### 2. SQLite Connection Management
**Problem**: All persistence stores opened NEW SQLite connections for EVERY database operation:
- `SqliteNodeDB`: 6 methods x many calls/second = rapid FD exhaustion
- `SqliteUserPrefsPersistence`: 3 methods
- `SqliteCommandLogger`: 6 methods

Under high packet load, `on_receive` calls `node_db.get_by_id()` frequently, opening hundreds of FD-consuming connections.

**Fix**:
- Modified `BaseSqlitePersistenceStore` to maintain a single persistent connection
- Added thread-safe RLock to coordinate access
- Enabled WAL mode for better concurrency

## Files Modified

- `src/api/BaseAPIWrapper.py`: Add requests.Session()
- `src/api/StorageAPI.py`: Fix error handling for non-HTTP exceptions
- `src/persistence/__init__.py`: Add persistent connection pool infrastructure
- `src/persistence/node_db.py`: Use persistent connection (6 methods)
- `src/persistence/user_prefs.py`: Use persistent connection (3 methods)
- `src/persistence/commands_logger.py`: Use persistent connection (6 methods)

## Background

SQLite file descriptor exhaustion occurs because:
1. Bot receives packets at high frequency (many/second in active mesh)
2. Each packet triggers `on_receive` callback
3. `on_receive` calls `node_db.get_by_id()` to look up sender node
4. Without persistent connections, each lookup opens a new FD
5. Old code pattern: `with sqlite3.connect(path) as conn:` in every method
6. Closed FDs not released quickly enough under load
7. System hits per-process FD limit (~1024 default), causing "unable to open database file"

## Testing performed

- Code review confirms connection reuse pattern
- Thread safety maintained with RLock on all database operations
- WAL mode enabled for SQLite concurrency
- Multiple persistence files use same pattern consistently

Ran full `meshtastic-bot` test suite: 100 passed

On the container side, have confirmed that `lsof` indicates usually a max of 32 connections to `node_db.sqlite`. 