### PR TITLE
chore: rename tidy — meshtastic-bot → meshflow-bot

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -55,8 +55,8 @@ jobs:
           outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
           build-args: |
             VERSION=${{ inputs.VERSION_LABEL }}
-          cache-from: type=gha,scope=${{ github.ref_name }}-meshtastic-bot
-          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-meshtastic-bot
+          cache-from: type=gha,scope=${{ github.ref_name }}-meshflow-bot
+          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-meshflow-bot
 
       - name: Export digest
         run: |
@@ -127,6 +127,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository_owner: ${{ github.repository_owner }}
-          package_name: meshtastic-bot
+          package_name: meshflow-bot
           owner_type: user
           untagged_only: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# Meshtastic Bot – Agent Context
+# Meshflow Bot – Agent Context
 
-Python bot for interacting with Meshtastic devices. Connects to a Meshtastic node over TCP, listens for messages, processes commands, and reports packets to the Meshflow API. Part of the Meshflow system alongside meshflow-api and meshtastic-bot-ui.
+Python bot for interacting with Meshtastic devices. Connects to a Meshtastic node over TCP, listens for messages, processes commands, and reports packets to the Meshflow API. Part of the Meshflow system alongside meshflow-api and meshflow-ui.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Meshtastic Bot
+# Meshflow Bot
 
-Meshtastic Bot is a Python-based bot for interacting with Meshtastic devices. It listens for messages, processes commands, and responds with appropriate actions. This guide is focused on helping you run the bot as-is, with minimal setup.
+Meshflow Bot is a Python-based bot for interacting with Meshtastic devices. It listens for messages, processes commands, and responds with appropriate actions. This guide is focused on helping you run the bot as-is, with minimal setup.
 
 ## Quick Start: Run with Docker
 
@@ -28,8 +28,8 @@ version: '3.8'
 
 services:
   bot:
-    image: ghcr.io/pskillen/meshtastic-bot:latest
-    container_name: meshtastic-bot
+    image: ghcr.io/pskillen/meshflow-bot:latest
+    container_name: meshflow-bot
     restart: unless-stopped
     environment:
       - MESHTASTIC_IP=${MESHTASTIC_NODE_IP}
@@ -63,8 +63,8 @@ If you prefer to run the bot natively (e.g., for development or customization):
 
 1. **Clone the repository:**
     ```sh
-    git clone https://github.com/yourusername/meshtastic-bot.git
-    cd meshtastic-bot
+    git clone https://github.com/pskillen/meshflow-bot.git
+    cd meshflow-bot
     ```
 2. **Install dependencies:**
     ```sh


### PR DESCRIPTION
## Summary

- Update `README.md` title, description, Docker image (`meshtastic-bot:latest` → `meshflow-bot:latest`), container name, and clone URL
- Update `AGENTS.md` heading: "Meshtastic Bot – Agent Context" → "Meshflow Bot – Agent Context"; update `meshtastic-bot-ui` reference → `meshflow-ui`
- Update `.github/workflows/docker-build.yaml` GHA cache scope names (2×) and GHCR `package_name`: `meshtastic-bot` → `meshflow-bot`

Part of the cleanup from the repo rename (`meshtastic-bot` → `meshflow-bot`). Related: pskillen/meshflow-api#270.

## Testing performed

- `grep -r "meshtastic-bot" README.md AGENTS.md .github/` returns no matches