### PR TITLE
feat(ci): publish legacy meshtastic-bot tags during migration window

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -107,11 +107,14 @@ jobs:
             VERSION="${{ inputs.VERSION_LABEL }}"
             MAJOR=$(echo "${VERSION}" | cut -d. -f1)
             MINOR=$(echo "${VERSION}" | cut -d. -f2)
+            LEGACY_IMAGE="ghcr.io/${{ github.repository_owner }}/meshtastic-bot"
             docker buildx imagetools create \
               -t ${{ env.IMAGE }}:${VERSION} \
               -t ${{ env.IMAGE }}:latest \
               -t ${{ env.IMAGE }}:${MAJOR} \
               -t ${{ env.IMAGE }}:${MAJOR}.${MINOR} \
+              -t ${LEGACY_IMAGE}:${VERSION} \
+              -t ${LEGACY_IMAGE}:latest \
               ${DIGEST_REFS}
           fi
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ services:
   bot:
     image: ghcr.io/pskillen/meshflow-bot:latest
     container_name: meshflow-bot
+    # Note: the legacy image name ghcr.io/pskillen/meshtastic-bot is deprecated
+    # and will be removed in a future release. Please update to meshflow-bot.
     restart: unless-stopped
     environment:
       - MESHTASTIC_IP=${MESHTASTIC_NODE_IP}


### PR DESCRIPTION
## Summary

- Update `.github/workflows/docker-build.yaml` prod release step to push both new (`meshflow-bot`) and legacy (`meshtastic-bot`) tags simultaneously
  - `ghcr.io/pskillen/meshtastic-bot:latest` and `ghcr.io/pskillen/meshtastic-bot:{VERSION}` are published alongside the new names
- Add deprecation notice in `README.md` docker-compose example

This gives volunteers running the old image name time to migrate before the legacy tag is dropped (see #81).

Closes #84. Stacks on #85 (rename tidy, merge that first).

## Testing performed

- Workflow YAML reviewed for correct `-t` flag syntax
- Legacy image path uses `${{ github.repository_owner }}` to stay owner-relative rather than hardcoding `pskillen`