### PR TITLE
feat(meshcore): Phase 0.3 capture-only MeshCore connectivity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,17 @@
-# The IP address of your Meshtastic node
+# The IP address of your Meshtastic node (when RADIO_PROTOCOL=meshtastic, the default)
 MESHTASTIC_IP=192.168.123.123
+
+# Radio protocol: meshtastic (default) or meshcore
+# RADIO_PROTOCOL=meshtastic
+
+# MeshCore (when RADIO_PROTOCOL=meshcore) — set exactly ONE of serial or BLE:
+# MESHCORE_SERIAL_DEVICE=/dev/ttyUSB0
+# MESHCORE_SERIAL_BAUD=115200
+# MESHCORE_BLE_ADDRESS=AA:BB:CC:DD:EE:FF
+# MESHCORE_BLE_PIN=
+# MESHCORE_DEBUG=false
+# MESHCORE_DUMP_ENABLED=true
+
 ADMIN_NODES='!aae8900d'
 
 # The root URL of the Meshflow API

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,108 +1,86 @@
 # Meshflow Bot – Agent Context
 
-Python bot for interacting with Meshtastic devices. Connects to a Meshtastic node over TCP, listens for messages, processes commands, and reports packets to the Meshflow API. Part of the Meshflow system alongside meshflow-api and meshflow-ui.
+Python bot for mesh radios: **Meshtastic** (TCP) and **MeshCore** (USB serial / BLE). Connects to a device, listens for messages, runs commands/responders, and (Meshtastic only) reports packets to meshflow-api. Part of the Meshflow system alongside meshflow-api and meshflow-ui.
+
+Protocol is selected at runtime with **`RADIO_PROTOCOL`** (`meshtastic` default, or `meshcore`). Adapters implement `RadioInterface` in [`src/radio/interface.py`](src/radio/interface.py).
 
 ## Project Structure
 
 ```
 src/
-├── main.py                    # Entry point, env config, bot setup
-├── bot.py                     # MeshtasticBot: pubsub handlers, connection, commands
-├── tcp_interface.py           # AutoReconnectTcpInterface (Meshtastic TCP connection)
-├── ws_client.py               # MeshflowWSClient – receives commands from API (e.g. traceroute)
-├── traceroute.py              # Traceroute command (triggered via WebSocket)
-├── data_classes.py            # MeshNode, packet data structures
-├── helpers.py                 # pretty_print_last_heard, safe_encode_node_name, etc.
-├── base_feature.py            # AbstractBaseFeature – reply_in_channel, message_in_dm, etc.
-├── commands/                  # Text commands (!help, !nodes, !ping, etc.)
-│   ├── factory.py             # CommandFactory – registers commands
-│   ├── command.py             # AbstractCommand base class
-│   ├── help.py, hello.py, nodes.py, ping.py, prefs.py, admin.py, template.py
-│   └── enroll.py              # (commented out)
-├── responders/                # Non-command message handlers
-│   ├── responder_factory.py   # ResponderFactory
-│   ├── responder.py           # AbstractResponder base class
-│   └── message_reaction_responder.py
-├── api/                       # Meshflow API integration
-│   ├── StorageAPI.py          # StorageAPIWrapper – packet ingestion, node sync
-│   ├── BaseAPIWrapper.py      # Base HTTP client
-│   └── serializers.py         # MeshNodeSerializer
-└── persistence/               # Local storage
-    ├── node_db.py             # AbstractNodeDB, SqliteNodeDB
-    ├── node_info.py           # AbstractNodeInfoStore, InMemoryNodeInfoStore
-    ├── commands_logger.py     # AbstractCommandLogger, SqliteCommandLogger
-    ├── user_prefs.py          # AbstractUserPrefsPersistence, SqliteUserPrefsPersistence
-    └── packet_dump.py         # Packet dump utilities
+├── main.py                 # Entry: build_radio(), StorageAPI / WS wiring
+├── bot.py                  # MeshflowBot (protocol-agnostic core)
+├── radio/                  # RadioInterface + shared events/errors
+├── meshtastic/             # MeshtasticRadio, TCP, translation, serializers
+├── meshcore/               # MeshCoreRadio (asyncio thread), translation, dump, serializers stub
+├── ws_client.py            # MeshflowWSClient (Meshtastic traceroute commands)
+├── data_classes.py         # MeshNode, shared models
+├── helpers.py
+├── base_feature.py
+├── commands/
+├── responders/
+├── api/                    # StorageAPIWrapper, serializers base
+└── persistence/
 
-test/                          # pytest unit tests
-deploy/                        # Deployment scripts (Raspberry Pi, Docker)
+docs/
+├── MESHTASTIC.md           # Meshtastic env + behaviour
+├── MESHCORE.md             # MeshCore capture-only (Phase 0.3)
+└── packets/                # Sample Meshtastic JSON fixtures
+
+test/
+deploy/
 ```
 
 ## Key Concepts
 
-- **MeshtasticBot**: Central class. Subscribes to pubsub (`meshtastic.receive`, `meshtastic.receive.text`, `meshtastic.node.updated`, `meshtastic.connection.established`). Owns interface, node_db, node_info, storage_apis, ws_client.
-- **Commands**: Text messages starting with `!` (e.g. `!help`, `!nodes`). Registered in `CommandFactory`; extend `AbstractCommand`.
-- **Responders**: Handle public channel messages without `!` prefix. Extend `AbstractResponder`.
-- **StorageAPIWrapper**: Reports raw packets and node data to Meshflow API. Supports v1 and v2 API paths. Uses `STORAGE_API_*` or `STORAGE_API_2_*` env vars.
-- **MeshflowWSClient**: Connects to `ws/nodes/?api_key=...` to receive remote commands (e.g. traceroute). Started after connection; uses same token as storage API.
+- **MeshflowBot** ([`src/bot.py`](src/bot.py)): Registers `RadioHandlers` on the active `RadioInterface`; scheduling, commands, responders, persistence, optional `StorageAPIWrapper` + `MeshflowWSClient`.
+- **MeshtasticRadio** ([`src/meshtastic/radio.py`](src/meshtastic/radio.py)): TCP + pubsub; translates to `IncomingPacket` / `IncomingTextMessage` / `NodeUpdate`.
+- **MeshCoreRadio** ([`src/meshcore/radio.py`](src/meshcore/radio.py)): Runs `meshcore` on a dedicated asyncio loop in a thread; dumps JSON to `data/meshcore_packets/`; Phase 0.3 **no** API upload.
+- **Commands / responders**: Same as before; extend `AbstractCommand` / `AbstractResponder`.
+- **StorageAPIWrapper**: Used when `RADIO_PROTOCOL=meshtastic` and `STORAGE_API_ROOT` is set.
+- **MeshflowWSClient**: Started only for `RADIO_PROTOCOL=meshtastic` when WS URL + token are configured.
 
-## API Integration
+## API Integration (Meshtastic)
 
-- **Packet ingestion**: `StorageAPIWrapper` posts to `/api/packets/{my_nodenum}/ingest/` (v2) or `/api/raw-packet/` (v1).
-- **Node sync**: `StorageAPIWrapper` fetches nodes from API for reconciliation.
-- **WebSocket**: `MeshflowWSClient` connects to Meshflow API; receives JSON commands (e.g. `{"type": "traceroute", "target_node_id": 123}`). Invokes `on_traceroute_command` on the bot.
+- **Packet ingestion**: v2 `POST /api/packets/{my_nodenum}/ingest/`, v1 `/api/raw-packet/`.
+- **Node sync**: `StorageAPIWrapper` node endpoints.
+- **WebSocket**: remote traceroute and similar commands.
 
 ## Development
 
 ```bash
-# activate venv
 source venv/bin/activate
-
 pip install -r requirements.txt
-# Copy .env.example to .env and configure
-python main.py
-# or: python -m src.main (from project root)
+cp .env.example .env
+python -m src.main
 ```
 
 ## Testing
 
 - **Unit tests**: `pytest test/ --doctest-modules`
-- Tests live under `test/` (commands, persistence, responders, etc.)
 - CI runs on Python 3.12, 3.13, 3.14
 
 ## Tech Stack
 
 - Python 3.12+
-- meshtastic (protobuf, TCP interface)
-- Pypubsub (pub/sub events)
-- requests (HTTP to Meshflow API)
-- websockets (MeshflowWSClient)
-- schedule (periodic tasks)
-- pytest
+- meshtastic, meshcore (PyPI), Pypubsub, requests, websockets, schedule, pytest
 
 ## Configuration
 
-Environment variables (see `.env.example`):
-
-- `MESHTASTIC_IP` – Meshtastic node IP (TCP connection)
-- `ADMIN_NODES` – Comma-separated node IDs (e.g. `!aae8900d`) for admin commands
-- `STORAGE_API_ROOT`, `STORAGE_API_TOKEN`, `STORAGE_API_VERSION` – Primary Meshflow API
-- `STORAGE_API_2_*` – Optional second API
-- `MESHFLOW_WS_URL` – WebSocket URL (optional; derived from storage API if unset)
-- `DATA_DIR` – Data directory (default `data/`)
+See [`.env.example`](.env.example), [docs/MESHTASTIC.md](docs/MESHTASTIC.md), and [docs/MESHCORE.md](docs/MESHCORE.md).
 
 ## Conventions
 
-- Commands: Add class to `src/commands/`, register in `CommandFactory.commands`.
-- Responders: Add class to `src/responders/`, register in `ResponderFactory`.
-- Use `reply_in_channel` / `reply_in_dm` from `AbstractBaseFeature`; avoid deprecated `reply` / `reply_to`.
-- Node IDs: hex string format (e.g. `!12345678`). `my_nodenum` is decimal.
-- Data persisted in `data/` (node_info.json, SQLite DBs, failed_packets).
+- Commands: `src/commands/`, register in `CommandFactory`.
+- Responders: `src/responders/`, register in `ResponderFactory`.
+- Use `reply_in_channel` / `reply_in_dm` from `AbstractBaseFeature`.
+- Meshtastic node IDs: `!` + 8 hex nibbles; `my_nodenum` is decimal.
+- MeshCore: pubkey-based ids (`mc:...`); `my_nodenum` is `None` for MC.
 
 ## Source control
 
 When asked to create a pull request description, follow the template at
-.github/pull_request_template.md, and output a markdown file named `tmp/PR.md`
+`.github/pull_request_template.md`, and output a markdown file named `tmp/PR.md`
 
 ## Plan mode
 

--- a/README.md
+++ b/README.md
@@ -1,67 +1,43 @@
 # Meshflow Bot
 
-Meshflow Bot is a Python-based bot for interacting with Meshtastic devices. It listens for messages, processes commands, and responds with appropriate actions. This guide is focused on helping you run the bot as-is, with minimal setup.
+Meshflow Bot is a Python bot that connects to **mesh radios** and integrates with [meshflow-api](https://github.com/pskillen/meshflow-api). It listens for traffic, handles `!` commands, optional responders, and (for Meshtastic) uploads packets to the API.
+
+**Protocols**
+
+- **[Meshtastic](docs/MESHTASTIC.md)** — TCP to a Meshtastic node; full API upload + WebSocket traceroute today.
+- **[MeshCore](docs/MESHCORE.md)** — USB serial or BLE via [`meshcore`](https://github.com/meshcore-dev/meshcore_py); **Phase 0.3** adds capture-only connectivity (JSON dumps under `data/meshcore_packets/`, no API ingest yet).
+
+Select the radio with `RADIO_PROTOCOL=meshtastic` (default) or `RADIO_PROTOCOL=meshcore`. See the linked docs for environment variables.
 
 ## Quick Start: Run with Docker
 
-The easiest way to run Meshtastic Bot is using Docker. This method requires minimal setup and keeps your environment clean.
+The easiest way to run the bot is Docker Compose. Two services are defined: `meshflow-bot-meshtastic` and `meshflow-bot-meshcore` (adjust devices, env, and image tags for your environment).
 
 ### 1. Prepare Your Environment
 
 - Ensure you have [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) installed.
-- Create a `.env` file in your project directory with the required environment variables:
+- Create a `.env` file in the project directory (see [`.env.example`](.env.example)).
 
-```
-MESHTASTIC_NODE_IP=your_meshtastic_node_ip
-ADMIN_NODES=comma_separated_admin_node_ids
-STORAGE_API_ROOT=your_storage_api_url
-STORAGE_API_TOKEN=your_storage_api_token
-# Optionally, you can upload to a second API as well
-STORAGE_API_2_ROOT=your_storage_api_2_url
-STORAGE_API_2_TOKEN=your_storage_api_2_token
-```
+### 2. Use `docker-compose.yaml`
 
-### 2. Use This `docker-compose.yaml`
-
-```yaml
-version: '3.8'
-
-services:
-  bot:
-    image: ghcr.io/pskillen/meshflow-bot:latest
-    container_name: meshflow-bot
-    # Note: the legacy image name ghcr.io/pskillen/meshtastic-bot is deprecated
-    # and will be removed in a future release. Please update to meshflow-bot.
-    restart: unless-stopped
-    environment:
-      - MESHTASTIC_IP=${MESHTASTIC_NODE_IP}
-      - ADMIN_NODES=${ADMIN_NODES}
-      - STORAGE_API_ROOT=${STORAGE_API_ROOT}
-      - STORAGE_API_TOKEN=${STORAGE_API_TOKEN}
-      - STORAGE_API_VERSION=2
-      - STORAGE_API_2_ROOT=${STORAGE_API_2_ROOT}
-      - STORAGE_API_2_TOKEN=${STORAGE_API_2_TOKEN}
-      - STORAGE_API_2_VERSION=2
-    volumes:
-      - mesh_bot_data:/app/data
-
-volumes:
-  mesh_bot_data:
-```
-
-### 3. Start the Bot
+From the repo root:
 
 ```sh
-docker compose up -d
+docker compose up -d meshflow-bot-meshtastic
+# or, for MeshCore over USB (Linux device pass-through):
+docker compose up -d meshflow-bot-meshcore
 ```
 
-The bot will now run in the background. Data will be persisted locally in the `mesh_bot_data` Docker volume.
+Images are published as `ghcr.io/pskillen/meshflow-bot` (the legacy `meshtastic-bot` image name is deprecated).
+
+### 3. Data directories
+
+- Meshtastic service mounts `./data`.
+- MeshCore service mounts `./data-meshcore` so captures do not clash with the MT bot.
 
 ---
 
 ## Native Installation (Advanced/Development)
-
-If you prefer to run the bot natively (e.g., for development or customization):
 
 1. **Clone the repository:**
     ```sh
@@ -77,17 +53,17 @@ If you prefer to run the bot natively (e.g., for development or customization):
     sudo apt-get install libopenblas-dev
     ```
 4. **Configure environment:**
-    - Copy `.env.example` to `.env` and fill in the required values.
+    - Copy `.env.example` to `.env` and fill in the required values (see [Meshtastic](docs/MESHTASTIC.md) / [MeshCore](docs/MESHCORE.md)).
 5. **Run the bot:**
     ```sh
-    python main.py
+    python -m src.main
     ```
 
 ---
 
 ## Usage
 
-The bot listens for messages and responds to commands. You can interact with it via supported Meshtastic channels.
+The bot listens for traffic and responds to `!` commands where the underlying protocol exposes text (Meshtastic today; MeshCore in capture mode still runs command dispatch for local testing).
 
 ### Supported Commands
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,17 +1,38 @@
 ---
 
 services:
-  meshtastic-bot:
-    image: ghcr.io/pskillen/meshtastic-bot:latest
+  meshflow-bot-meshtastic:
+    image: ghcr.io/pskillen/meshflow-bot:latest
     build:
       context: "./"
-    container_name: meshtastic-bot
+    container_name: meshflow-bot-meshtastic
     restart: unless-stopped
     environment:
+      - RADIO_PROTOCOL=meshtastic
       - MESHTASTIC_IP=meshtastic.local
-      - ADMIN_NODES='!aae8900d'  # Change this, unless you want me to be the admin of your bot
+      - ADMIN_NODES='!aae8900d' # Change this, unless you want me to be the admin of your bot
     volumes:
       - ./data:/app/data
+    depends_on:
+      - watchtower
+
+  meshflow-bot-meshcore:
+    image: ghcr.io/pskillen/meshflow-bot:latest
+    build:
+      context: "./"
+    container_name: meshflow-bot-meshcore
+    restart: unless-stopped
+    environment:
+      - RADIO_PROTOCOL=meshcore
+      - MESHCORE_SERIAL_DEVICE=/dev/ttyUSB0
+      # Optional: BLE instead of serial (set only one of serial or BLE)
+      # - MESHCORE_BLE_ADDRESS=AA:BB:CC:DD:EE:FF
+      # - MESHCORE_BLE_PIN=
+      - ADMIN_NODES='!aae8900d'
+    devices:
+      - /dev/ttyUSB0:/dev/ttyUSB0
+    volumes:
+      - ./data-meshcore:/app/data
     depends_on:
       - watchtower
 
@@ -21,4 +42,4 @@ services:
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    command: --interval 3600 meshtastic-bot  # Check for updates every hour
+    command: --interval 3600 meshflow-bot-meshtastic meshflow-bot-meshcore

--- a/docs/MESHCORE.md
+++ b/docs/MESHCORE.md
@@ -1,0 +1,65 @@
+# MeshCore (Phase 0.3 — capture-only)
+
+[MeshCore](https://meshcore.co.uk) is a mesh radio protocol and companion firmware family. This bot integrates via the [`meshcore` PyPI package](https://github.com/meshcore-dev/meshcore_py) (Python bindings).
+
+**Phase 0.3 scope:** connect, receive events, translate them into the bot’s generic `RadioInterface` events, and write JSON captures under `data/meshcore_packets/<event_type>/`. **No** Meshflow API upload (`StorageAPIWrapper` is disabled when `RADIO_PROTOCOL=meshcore`).
+
+## Transports
+
+| Transport | Env vars | Notes |
+|-----------|-----------|--------|
+| **USB serial** (default) | `MESHCORE_SERIAL_DEVICE` (e.g. `/dev/ttyUSB0`) | On Linux, user usually needs `dialout` group membership for the device node. |
+| **Bluetooth LE** | `MESHCORE_BLE_ADDRESS` (e.g. `AA:BB:CC:DD:EE:FF`), optional `MESHCORE_BLE_PIN` | Set **either** serial **or** BLE, not both. Requires platform BLE stack + `meshcore` dependencies. |
+
+TCP is supported by `meshcore` but not wired in this bot build (add later if needed).
+
+## Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `RADIO_PROTOCOL` | Must be `meshcore` for this mode. |
+| `MESHCORE_SERIAL_DEVICE` | Serial device path (mutually exclusive with BLE). |
+| `MESHCORE_BLE_ADDRESS` | BLE MAC / address (mutually exclusive with serial). |
+| `MESHCORE_BLE_PIN` | Optional pairing PIN string. |
+| `MESHCORE_SERIAL_BAUD` | Serial baud rate (default `115200`). |
+| `MESHCORE_DEBUG` | `true` / `1` enables verbose `meshcore` logging. |
+| `MESHCORE_DUMP_ENABLED` | `true` / `false` — write JSON dumps (default `true`). |
+| `MESHCORE_MAX_RECONNECT_ATTEMPTS` | Passed to `meshcore` auto-reconnect (default `100`). |
+| `ADMIN_NODES` | Same as Meshtastic: comma-separated admin ids (format may evolve for MC). |
+| `DATA_DIR` | Base data directory (default `data/`). |
+
+`STORAGE_API_*` is ignored with a log line in Phase 0.3. The MeshCore WebSocket command channel is not started (traceroute is Meshtastic-only today).
+
+## Local identity
+
+MeshCore nodes are identified by **Ed25519 public keys** (64 hex chars), not Meshtastic-style 32-bit node numbers.
+
+- `MeshCoreRadio.local_node_id` is exposed as `mc:` + the first **12** hex characters of the companion’s public key after `SELF_INFO` (or `mc:unknown` if that event is missing).
+- `local_nodenum` is always `None` for MeshCore. `ConnectionEstablished.local_nodenum` is set to `0` as a placeholder for logging only.
+
+Remote senders in DMs use ids like `mc:p:<12-hex-prefix>` when only a short prefix is on the wire.
+
+## Running
+
+```bash
+source venv/bin/activate
+export RADIO_PROTOCOL=meshcore
+export MESHCORE_SERIAL_DEVICE=/dev/ttyUSB0
+python -m src.main
+```
+
+Docker Compose: use the `meshflow-bot-meshcore` service in `docker-compose.yaml` (pass-through of `/dev/ttyUSB0` is Linux-specific; adjust the device path for your host).
+
+## Capture layout
+
+Each JSON file:
+
+- Top-level `"protocol": "meshcore"`.
+- `event_type`, `payload`, `attributes` mirroring `meshcore.events.Event`.
+
+High-frequency types `no_more_messages` and `command_ok` are **not** written to disk (still processed for the live session).
+
+## Next phases
+
+- **0.4:** Long capture campaign to inform API schema.
+- **1.x:** `MeshCorePacketSerializer` + `POST /api/meshcore/.../ingest/` and opt-in `MESHCORE_UPLOAD_ENABLED`.

--- a/docs/MESHTASTIC.md
+++ b/docs/MESHTASTIC.md
@@ -1,0 +1,63 @@
+# Meshtastic
+
+[Meshtastic](https://meshtastic.org) is an open LoRa mesh firmware ecosystem. Meshflow Bot speaks to a node over **TCP** using the official [`meshtastic`](https://pypi.org/project/meshtastic/) Python library. The adapter lives under [`src/meshtastic/`](../src/meshtastic/).
+
+## Connection
+
+| Variable | Description |
+|----------|-------------|
+| `RADIO_PROTOCOL` | Use `meshtastic` (default) or omit (defaults to Meshtastic). |
+| `MESHTASTIC_IP` | Hostname or IP of the node’s TCP API (required for Meshtastic mode). |
+
+The concrete radio implementation is `MeshtasticRadio` in [`src/meshtastic/radio.py`](../src/meshtastic/radio.py) (auto-reconnect TCP, pubsub, packet translation).
+
+## Meshflow API upload
+
+When `STORAGE_API_ROOT` is set and `RADIO_PROTOCOL=meshtastic`:
+
+- **v2:** `POST /api/packets/{my_nodenum}/ingest/` for raw packets.
+- **v1:** `POST /api/raw-packet/`.
+
+| Variable | Description |
+|----------|-------------|
+| `STORAGE_API_ROOT` | Base URL of meshflow-api |
+| `STORAGE_API_TOKEN` | Bearer / API token |
+| `STORAGE_API_VERSION` | `1` or `2` |
+| `STORAGE_API_2_*` | Optional second destination |
+
+Failed uploads can be retained under `data/failed_packets/` when configured.
+
+## WebSocket commands
+
+With `MESHFLOW_WS_URL` + token (or derived from `STORAGE_API_*`), the bot starts `MeshflowWSClient` for remote actions such as **traceroute** after the radio connects.
+
+## Optional behaviour
+
+| Variable | Description |
+|----------|-------------|
+| `IGNORE_PORTNUMS` | Comma-separated portnums to skip when uploading (upper-case, e.g. `ROUTING_APP`). |
+| `DUMP_PACKETS_PORTNUMS` | Comma-separated Meshtastic `portnum` names (or `*`) to mirror received packets as JSON under `data/packets/<PORTNUM>/`. See [`src/persistence/packet_dump.py`](../src/persistence/packet_dump.py). |
+| `ADMIN_NODES` | Comma-separated `!hex8` node ids allowed to run admin commands. |
+| `DATA_DIR` | Data root (default `data/`). |
+
+## Sample packet JSON
+
+Example Meshtastic-shaped packets for tests/docs live under [`docs/packets/`](packets/) (encrypted, nodeinfo, position, routing, telemetry, text).
+
+## Running
+
+```bash
+source venv/bin/activate
+export RADIO_PROTOCOL=meshtastic   # optional; this is the default
+export MESHTASTIC_IP=192.168.1.50
+export STORAGE_API_ROOT=https://api.example.com
+export STORAGE_API_TOKEN=...
+export STORAGE_API_VERSION=2
+python -m src.main
+```
+
+Docker: use the `meshflow-bot-meshtastic` service in [`docker-compose.yaml`](../docker-compose.yaml).
+
+## See also
+
+- [MeshCore capture mode](MESHCORE.md) — second protocol, USB/BLE, no API upload in Phase 0.3.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 meshtastic>=2.5.0,<3.0.0
+meshcore>=2.3.7,<3.0.0
 websockets>=14.0
 Pypubsub~=4.0.3
 jinja2~=3.1.6

--- a/src/bot.py
+++ b/src/bot.py
@@ -117,7 +117,10 @@ class MeshflowBot:
 
     def _on_packet(self, event: IncomingPacket) -> None:
         if event.raw is not None:
-            dump_packet(event.raw)
+            if isinstance(event.raw, dict) and event.raw.get("meshcore"):
+                pass  # MeshCore JSON dumps live under data/meshcore_packets/ (see MeshCoreRadio)
+            elif isinstance(event.raw, dict) and "decoded" in event.raw:
+                dump_packet(event.raw)
 
         if self.ignore_portnums and event.portnum in self.ignore_portnums:
             logger.info(

--- a/src/main.py
+++ b/src/main.py
@@ -29,7 +29,10 @@ logging.getLogger("mesh_interface").setLevel(logging.WARNING)
 
 # Now we can import the rest of our local files
 from src.api.StorageAPI import StorageAPIWrapper
+from src.api.packet_serializer import PacketSerializer
 from src.bot import MeshflowBot
+from src.meshcore.radio import MeshCoreRadio
+from src.meshcore.serializers import MeshCorePacketSerializer
 from src.meshtastic.radio import MeshtasticRadio
 from src.meshtastic.serializers import MeshtasticPacketSerializer
 from src.persistence.commands_logger import SqliteCommandLogger
@@ -41,6 +44,11 @@ from src.ws_client import MeshflowWSClient
 
 RADIO_PROTOCOL = os.getenv("RADIO_PROTOCOL", "meshtastic").lower()
 MESHTASTIC_IP = os.getenv("MESHTASTIC_IP")
+MESHCORE_SERIAL_DEVICE = os.getenv("MESHCORE_SERIAL_DEVICE")
+MESHCORE_BLE_ADDRESS = os.getenv("MESHCORE_BLE_ADDRESS")
+MESHCORE_BLE_PIN = os.getenv("MESHCORE_BLE_PIN")
+MESHCORE_SERIAL_BAUD = int(os.getenv("MESHCORE_SERIAL_BAUD", "115200"))
+MESHCORE_DEBUG = os.getenv("MESHCORE_DEBUG", "false").lower() in ("1", "true", "yes")
 ADMIN_NODES = os.getenv("ADMIN_NODES", "").split(",")
 DATA_DIR = os.getenv("DATA_DIR", "data")
 STORAGE_API_ROOT = os.getenv("STORAGE_API_ROOT")
@@ -57,13 +65,32 @@ IGNORE_PORTNUMS = frozenset(
 )
 
 
-def build_radio() -> tuple[RadioInterface, "object"]:
+def build_radio(data_dir: Path) -> tuple[RadioInterface, PacketSerializer]:
     """Build the configured :class:`RadioInterface` and a matching
     :class:`PacketSerializer` for the storage uploader."""
     if RADIO_PROTOCOL == "meshtastic":
         if not MESHTASTIC_IP:
             raise RuntimeError("MESHTASTIC_IP must be set when RADIO_PROTOCOL=meshtastic")
         return MeshtasticRadio(MESHTASTIC_IP), MeshtasticPacketSerializer()
+    if RADIO_PROTOCOL == "meshcore":
+        serial = MESHCORE_SERIAL_DEVICE
+        ble = MESHCORE_BLE_ADDRESS
+        if bool(serial) == bool(ble):
+            raise RuntimeError(
+                "Set exactly one of MESHCORE_SERIAL_DEVICE or MESHCORE_BLE_ADDRESS "
+                "when RADIO_PROTOCOL=meshcore"
+            )
+        return (
+            MeshCoreRadio(
+                serial_device=serial,
+                ble_address=ble,
+                ble_pin=MESHCORE_BLE_PIN or None,
+                baudrate=MESHCORE_SERIAL_BAUD,
+                debug=MESHCORE_DEBUG,
+                data_dir=data_dir,
+            ),
+            MeshCorePacketSerializer(),
+        )
     raise ValueError(f"Unsupported RADIO_PROTOCOL={RADIO_PROTOCOL!r}")
 
 
@@ -76,7 +103,7 @@ def main() -> None:
     node_info_file = data_dir / "node_info.json"
     failed_packets_dir = data_dir / "failed_packets"
 
-    radio, serializer = build_radio()
+    radio, serializer = build_radio(data_dir)
     bot = MeshflowBot(radio=radio)
     bot.ignore_portnums = IGNORE_PORTNUMS
     bot.admin_nodes = ADMIN_NODES
@@ -86,7 +113,7 @@ def main() -> None:
     node_info = InMemoryNodeInfoStore()
     bot.node_info = node_info
 
-    if STORAGE_API_ROOT:
+    if STORAGE_API_ROOT and RADIO_PROTOCOL == "meshtastic":
         bot.storage_apis.append(
             StorageAPIWrapper(
                 STORAGE_API_ROOT,
@@ -97,7 +124,12 @@ def main() -> None:
                 local_nodenum_provider=lambda: bot.my_nodenum,
             )
         )
-    if STORAGE_API_2_ROOT:
+    elif STORAGE_API_ROOT and RADIO_PROTOCOL == "meshcore":
+        logging.info(
+            "RADIO_PROTOCOL=meshcore: API upload disabled in Phase 0.3 (capture-only); "
+            "ignoring STORAGE_API_ROOT"
+        )
+    if STORAGE_API_2_ROOT and RADIO_PROTOCOL == "meshtastic":
         bot.storage_apis.append(
             StorageAPIWrapper(
                 STORAGE_API_2_ROOT,
@@ -108,6 +140,8 @@ def main() -> None:
                 local_nodenum_provider=lambda: bot.my_nodenum,
             )
         )
+    elif STORAGE_API_2_ROOT and RADIO_PROTOCOL == "meshcore":
+        logging.info("RADIO_PROTOCOL=meshcore: ignoring STORAGE_API_2_ROOT (capture-only)")
 
     # WebSocket client (e.g. for remote traceroute commands)
     ws_url = MESHFLOW_WS_URL
@@ -118,7 +152,7 @@ def main() -> None:
         )
     if STORAGE_API_ROOT and STORAGE_API_TOKEN:
         ws_token = STORAGE_API_TOKEN
-    if ws_url and ws_token:
+    if ws_url and ws_token and RADIO_PROTOCOL == "meshtastic":
         bot.ws_client = MeshflowWSClient(
             ws_url=ws_url,
             api_key=ws_token,

--- a/src/meshcore/__init__.py
+++ b/src/meshcore/__init__.py
@@ -1,0 +1,5 @@
+"""MeshCore radio adapter (capture-only in Phase 0.3)."""
+
+from src.meshcore.radio import MeshCoreRadio
+
+__all__ = ["MeshCoreRadio"]

--- a/src/meshcore/dump.py
+++ b/src/meshcore/dump.py
@@ -1,0 +1,54 @@
+"""Write MeshCore :class:`meshcore.events.Event` captures to JSON files."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _json_safe(obj: Any) -> Any:
+    """Recursively convert payloads to JSON-serialisable structures."""
+    if isinstance(obj, dict):
+        return {str(k): _json_safe(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_json_safe(x) for x in obj]
+    if isinstance(obj, (str, int, float, bool)) or obj is None:
+        return obj
+    if isinstance(obj, bytes):
+        return obj.hex()
+    return str(obj)
+
+
+def dump_meshcore_event(
+    *,
+    event_type: str,
+    payload: Any,
+    attributes: dict[str, Any],
+    base_dir: Path,
+) -> Path | None:
+    """Write one event under ``base_dir/meshcore_packets/<event_type>/``.
+
+    Returns the path written, or ``None`` if writing failed.
+    """
+    out_dir = base_dir / "meshcore_packets" / event_type
+    out_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S_%f")
+    path = out_dir / f"{ts}.json"
+    record = {
+        "protocol": "meshcore",
+        "event_type": event_type,
+        "payload": _json_safe(payload),
+        "attributes": _json_safe(attributes),
+    }
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(record, f, indent=2)
+        return path
+    except OSError as exc:
+        logger.error("MeshCore dump failed: %s", exc)
+        return None

--- a/src/meshcore/radio.py
+++ b/src/meshcore/radio.py
@@ -1,0 +1,303 @@
+"""MeshCore :class:`~src.radio.interface.RadioInterface` using ``meshcore`` (asyncio)."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import threading
+from pathlib import Path
+from typing import Optional
+
+from meshcore import MeshCore
+from meshcore.events import Event, EventType
+
+from src.meshcore.dump import dump_meshcore_event
+from src.meshcore.translation import (
+    event_to_incoming_packet,
+    event_to_node_update,
+    event_to_text_message,
+)
+from src.radio.errors import RadioError, call_safely, get_global_error_counter
+from src.radio.events import ConnectionEstablished
+from src.radio.interface import RadioHandlers, RadioInterface
+
+logger = logging.getLogger(__name__)
+
+# Do not JSON-dump high-frequency command plumbing (still forwarded to handlers).
+_SKIP_MESHCORE_DUMP_TYPES = frozenset(
+    {
+        EventType.NO_MORE_MSGS,
+        EventType.OK,
+    }
+)
+
+
+class MeshCoreRadio(RadioInterface):
+    """Runs ``meshcore`` on a dedicated asyncio loop in a background thread."""
+
+    def __init__(
+        self,
+        *,
+        serial_device: Optional[str] = None,
+        ble_address: Optional[str] = None,
+        ble_pin: Optional[str] = None,
+        baudrate: int = 115200,
+        debug: bool = False,
+        data_dir: Optional[Path] = None,
+    ) -> None:
+        if bool(serial_device) == bool(ble_address):
+            raise ValueError("Set exactly one of serial_device or ble_address")
+        self._serial = serial_device
+        self._ble = ble_address
+        self._ble_pin = ble_pin
+        self._baudrate = baudrate
+        self._debug = debug
+        self._data_dir = data_dir or Path("data")
+
+        self._handlers = RadioHandlers()
+        self._meshcore: Optional[MeshCore] = None
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._thread: Optional[threading.Thread] = None
+        self._shutdown = threading.Event()
+        self._started = threading.Event()
+        self._startup_error: Optional[BaseException] = None
+        self._connected_once = False
+        self._local_node_id: Optional[str] = None
+        self._error_counter = get_global_error_counter()
+
+        self._dump_enabled = os.getenv("MESHCORE_DUMP_ENABLED", "true").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+
+    def set_handlers(self, handlers: RadioHandlers) -> None:
+        self._handlers = handlers
+
+    def connect(self) -> None:
+        if self._thread and self._thread.is_alive():
+            return
+        self._shutdown.clear()
+        self._started.clear()
+        self._startup_error = None
+        self._thread = threading.Thread(target=self._thread_main, name="meshcore-radio", daemon=True)
+        self._thread.start()
+        if not self._started.wait(timeout=60.0):
+            raise RadioError("MeshCoreRadio: timed out waiting for background connect")
+        if self._startup_error is not None:
+            raise RadioError(f"MeshCoreRadio: connect failed: {self._startup_error!r}") from self._startup_error
+
+    def disconnect(self) -> None:
+        self._shutdown.set()
+        loop = self._loop
+        if loop and loop.is_running():
+            fut = asyncio.run_coroutine_threadsafe(self._async_shutdown(), loop)
+            try:
+                fut.result(timeout=30.0)
+            except Exception as exc:
+                logger.warning("MeshCoreRadio disconnect: %s", exc)
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=5.0)
+        self._thread = None
+        self._loop = None
+        self._meshcore = None
+        self._connected_once = False
+
+    @property
+    def is_connected(self) -> bool:
+        return bool(self._meshcore and self._meshcore.is_connected)
+
+    @property
+    def local_node_id(self) -> Optional[str]:
+        return self._local_node_id
+
+    @property
+    def local_nodenum(self) -> Optional[int]:
+        """MeshCore nodes are pubkey-keyed; no Meshtastic-style nodenum."""
+        return None
+
+    def send_text(
+        self,
+        text: str,
+        *,
+        destination_id: Optional[str] = None,
+        channel: int = 0,
+        want_ack: bool = False,
+        hop_limit: Optional[int] = None,
+    ) -> None:
+        raise RadioError("MeshCore send not implemented in 0.3 capture-only mode")
+
+    def send_reaction(
+        self,
+        emoji: str,
+        message_id: int,
+        *,
+        destination_id: Optional[str] = None,
+        channel: int = 0,
+    ) -> None:
+        raise RadioError("MeshCore send not implemented in 0.3 capture-only mode")
+
+    def send_traceroute(
+        self,
+        target_node_id: int,
+        *,
+        channel_index: int = 0,
+    ) -> None:
+        raise RadioError("MeshCore send not implemented in 0.3 capture-only mode")
+
+    # --- internals --------------------------------------------------------
+
+    def _thread_main(self) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        self._loop = loop
+        try:
+            loop.run_until_complete(self._async_main())
+        finally:
+            try:
+                pending = asyncio.all_tasks(loop)
+                for t in pending:
+                    t.cancel()
+                if pending:
+                    loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+            except Exception:
+                logger.exception("MeshCoreRadio: error cancelling pending tasks")
+            loop.close()
+            self._loop = None
+
+    async def _async_main(self) -> None:
+        try:
+            await self._run_session()
+        except BaseException as exc:
+            logger.exception("MeshCoreRadio session ended with error")
+            self._startup_error = exc
+            self._started.set()
+
+    async def _run_session(self) -> None:
+        max_attempts = int(os.getenv("MESHCORE_MAX_RECONNECT_ATTEMPTS", "100"))
+        if self._serial:
+            mc = await MeshCore.create_serial(
+                self._serial,
+                self._baudrate,
+                debug=self._debug,
+                auto_reconnect=True,
+                max_reconnect_attempts=max_attempts,
+            )
+        else:
+            mc = await MeshCore.create_ble(
+                self._ble,
+                pin=self._ble_pin,
+                debug=self._debug,
+                auto_reconnect=True,
+                max_reconnect_attempts=max_attempts,
+            )
+        if mc is None:
+            raise RadioError("MeshCore.create_* returned None (device not responding)")
+
+        self._meshcore = mc
+
+        mc.subscribe(None, self._on_any_event)
+
+        await mc.start_auto_message_fetching()
+
+        self_info_evt = await mc.wait_for_event(EventType.SELF_INFO, timeout=5.0)
+        pubkey = ""
+        if self_info_evt and isinstance(self_info_evt.payload, dict):
+            pubkey = str(self_info_evt.payload.get("public_key", "") or "")
+        if not pubkey and mc.self_info:
+            pubkey = str(mc.self_info.get("public_key", "") or "")
+        self._local_node_id = f"mc:{pubkey[:12]}" if pubkey else "mc:unknown"
+
+        if not self._connected_once:
+            self._connected_once = True
+            if self._handlers.on_connection_established:
+                call_safely(
+                    "meshcore.on_connection_established",
+                    self._handlers.on_connection_established,
+                    ConnectionEstablished(
+                        local_node_id=self._local_node_id,
+                        local_nodenum=0,
+                        extras={"meshcore": True, "public_key_prefix": pubkey[:12]},
+                    ),
+                    counter=self._error_counter,
+                )
+
+        self._started.set()
+        await self._wait_until_shutdown()
+
+    async def _wait_until_shutdown(self) -> None:
+        while not self._shutdown.is_set():
+            await asyncio.sleep(0.25)
+
+    async def _async_shutdown(self) -> None:
+        mc = self._meshcore
+        if mc:
+            try:
+                await mc.disconnect()
+            except Exception:
+                logger.exception("MeshCore.disconnect failed")
+        self._meshcore = None
+
+    async def _on_any_event(self, event: Event) -> None:
+        """Central ingress: dump, then translate to bot handlers."""
+        try:
+            self._dispatch_meshcore_event(event)
+        except Exception:
+            self._error_counter.increment("meshcore.on_any_event")
+            logger.exception("MeshCoreRadio._on_any_event")
+
+    def dispatch_meshcore_event_for_tests(self, event: Event) -> None:
+        """Synchronous hook for unit tests (same path as async subscriber)."""
+        self._dispatch_meshcore_event(event)
+
+    def _dispatch_meshcore_event(self, event: Event) -> None:
+        et = event.type
+        if self._dump_enabled and et not in _SKIP_MESHCORE_DUMP_TYPES:
+            dump_meshcore_event(
+                event_type=et.value,
+                payload=event.payload,
+                attributes=dict(event.attributes) if event.attributes else {},
+                base_dir=self._data_dir,
+            )
+
+        if et == EventType.DISCONNECTED:
+            reason = ""
+            if isinstance(event.payload, dict):
+                reason = str(event.payload.get("reason", ""))
+            if self._handlers.on_disconnected:
+                err: Optional[Exception] = RadioError(reason) if reason else None
+                call_safely(
+                    "meshcore.on_disconnected",
+                    self._handlers.on_disconnected,
+                    err,
+                    counter=self._error_counter,
+                )
+            return
+
+        incoming = event_to_incoming_packet(event)
+        if incoming and self._handlers.on_packet:
+            call_safely(
+                "meshcore.on_packet",
+                self._handlers.on_packet,
+                incoming,
+                counter=self._error_counter,
+            )
+
+        text = event_to_text_message(event, local_node_id=self._local_node_id)
+        if text and text.text and self._handlers.on_text_message:
+            call_safely(
+                "meshcore.on_text_message",
+                self._handlers.on_text_message,
+                text,
+                counter=self._error_counter,
+            )
+
+        node_upd = event_to_node_update(event)
+        if node_upd and self._handlers.on_node_update:
+            call_safely(
+                "meshcore.on_node_update",
+                self._handlers.on_node_update,
+                node_upd,
+                counter=self._error_counter,
+            )

--- a/src/meshcore/serializers.py
+++ b/src/meshcore/serializers.py
@@ -1,0 +1,27 @@
+"""MeshCore :class:`~src.api.packet_serializer.PacketSerializer` (stub for Phase 0.3)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.api.packet_serializer import PacketSerializer
+from src.data_classes import MeshNode
+
+
+class MeshCorePacketSerializer(PacketSerializer):
+    """Capture-only placeholder; Phase 1 wires :meth:`serialise_raw_packet`."""
+
+    def serialise_raw_packet(self, packet: Any) -> dict:
+        raise NotImplementedError(
+            "MeshCorePacketSerializer.serialise_raw_packet is not implemented until Phase 1"
+        )
+
+    def serialise_node(self, node: MeshNode) -> dict:
+        raise NotImplementedError(
+            "MeshCorePacketSerializer.serialise_node is not implemented until Phase 1"
+        )
+
+    def deserialise_node(self, node_data: dict) -> MeshNode:
+        raise NotImplementedError(
+            "MeshCorePacketSerializer.deserialise_node is not implemented until Phase 1"
+        )

--- a/src/meshcore/translation.py
+++ b/src/meshcore/translation.py
@@ -1,0 +1,264 @@
+"""Translate :mod:`meshcore` events into bot :mod:`src.radio.events`."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from meshcore.events import Event, EventType
+
+from src.data_classes import MeshNode
+from src.radio.events import IncomingPacket, IncomingTextMessage, NodeUpdate
+
+
+def mc_id_from_full_pubkey(pubkey_hex: str) -> str:
+    """Stable node id for a 32-byte (64-hex) MeshCore public key."""
+    return f"mc:{pubkey_hex.lower()}"
+
+
+def mc_id_from_prefix(pubkey_prefix_hex: str) -> str:
+    """Node id for a 6-byte (12-hex) sender prefix from a message frame."""
+    return f"mc:p:{pubkey_prefix_hex.lower()}"
+
+
+def event_type_to_portnum(event_type: EventType) -> str:
+    """Upper-case analogue of Meshtastic ``portnum`` for ``IncomingPacket``."""
+    return f"MC_{event_type.name}"
+
+
+def event_to_incoming_packet(event: Event) -> Optional[IncomingPacket]:
+    """Build an :class:`IncomingPacket` for storage/dispatch, or ``None`` to skip."""
+    et = event.type
+    payload = event.payload if isinstance(event.payload, dict) else {}
+
+    if et == EventType.CONTACT_MSG_RECV:
+        from_id = None
+        if "pubkey_prefix" in payload:
+            from_id = mc_id_from_prefix(str(payload["pubkey_prefix"]))
+        return IncomingPacket(
+            portnum=event_type_to_portnum(et),
+            from_id=from_id,
+            to_id=None,
+            channel=int(payload.get("channel_idx", 0)),
+            has_decoded=True,
+            is_self_telemetry=False,
+            raw=_raw_envelope(event),
+        )
+
+    if et == EventType.CHANNEL_MSG_RECV:
+        ch = int(payload.get("channel_idx", 0))
+        # Channel frames do not always include a sender pubkey; keep a stable placeholder.
+        from_id = f"mc:channel:{ch}:rx"
+        return IncomingPacket(
+            portnum=event_type_to_portnum(et),
+            from_id=from_id,
+            to_id=None,
+            channel=ch,
+            has_decoded=True,
+            is_self_telemetry=False,
+            raw=_raw_envelope(event),
+        )
+
+    if et == EventType.ADVERTISEMENT:
+        pk = str(payload.get("public_key", ""))
+        from_id = mc_id_from_full_pubkey(pk) if pk else None
+        return IncomingPacket(
+            portnum=event_type_to_portnum(et),
+            from_id=from_id,
+            to_id=None,
+            channel=0,
+            has_decoded=True,
+            is_self_telemetry=False,
+            raw=_raw_envelope(event),
+        )
+
+    if et == EventType.PATH_UPDATE:
+        pk = str(payload.get("public_key", ""))
+        from_id = mc_id_from_full_pubkey(pk) if pk else None
+        return IncomingPacket(
+            portnum=event_type_to_portnum(et),
+            from_id=from_id,
+            to_id=None,
+            channel=0,
+            has_decoded=True,
+            is_self_telemetry=False,
+            raw=_raw_envelope(event),
+        )
+
+    if et == EventType.ACK:
+        return IncomingPacket(
+            portnum=event_type_to_portnum(et),
+            from_id=None,
+            to_id=None,
+            channel=0,
+            has_decoded=True,
+            is_self_telemetry=False,
+            raw=_raw_envelope(event),
+        )
+
+    if et == EventType.BATTERY:
+        return IncomingPacket(
+            portnum=event_type_to_portnum(et),
+            from_id=None,
+            to_id=None,
+            channel=0,
+            has_decoded=True,
+            is_self_telemetry=True,
+            raw=_raw_envelope(event),
+        )
+
+    if et == EventType.RAW_DATA:
+        return IncomingPacket(
+            portnum=event_type_to_portnum(et),
+            from_id=None,
+            to_id=None,
+            channel=0,
+            has_decoded=True,
+            is_self_telemetry=False,
+            raw=_raw_envelope(event),
+        )
+
+    if et == EventType.MESSAGES_WAITING:
+        return IncomingPacket(
+            portnum=event_type_to_portnum(et),
+            from_id=None,
+            to_id=None,
+            channel=0,
+            has_decoded=True,
+            is_self_telemetry=False,
+            raw=_raw_envelope(event),
+        )
+
+    if et == EventType.SELF_INFO:
+        pk = str(payload.get("public_key", ""))
+        from_id = mc_id_from_full_pubkey(pk) if pk else None
+        return IncomingPacket(
+            portnum=event_type_to_portnum(et),
+            from_id=from_id,
+            to_id=None,
+            channel=0,
+            has_decoded=True,
+            is_self_telemetry=True,
+            raw=_raw_envelope(event),
+        )
+
+    if et == EventType.DEVICE_INFO:
+        return IncomingPacket(
+            portnum=event_type_to_portnum(et),
+            from_id=None,
+            to_id=None,
+            channel=0,
+            has_decoded=True,
+            is_self_telemetry=False,
+            raw=_raw_envelope(event),
+        )
+
+    return None
+
+
+def event_to_text_message(
+    event: Event,
+    *,
+    local_node_id: Optional[str],
+) -> Optional[IncomingTextMessage]:
+    """Decoded text path for commands/responders."""
+    if event.type not in (EventType.CONTACT_MSG_RECV, EventType.CHANNEL_MSG_RECV):
+        return None
+    payload = event.payload if isinstance(event.payload, dict) else {}
+    text = str(payload.get("text", ""))
+    is_dm = payload.get("type") == "PRIV"
+    ch = int(payload.get("channel_idx", 0))
+    if event.type == EventType.CONTACT_MSG_RECV:
+        prefix = str(payload.get("pubkey_prefix", ""))
+        if not prefix:
+            return None
+        from_id = mc_id_from_prefix(prefix)
+    else:
+        from_id = f"mc:channel:{ch}:rx"
+    if is_dm:
+        to_id = local_node_id or ""
+    else:
+        to_id = f"mc:channel:{ch}"
+    return IncomingTextMessage(
+        text=text,
+        from_id=from_id,
+        to_id=to_id,
+        channel=ch,
+        message_id=0,
+        hop_start=0,
+        hop_limit=0,
+        is_dm=is_dm,
+        raw=_raw_envelope(event),
+    )
+
+
+def _contact_payload_to_node(contact: dict[str, Any]) -> MeshNode:
+    """Build a :class:`MeshNode` from a MeshCore contact/advert dict."""
+    pubkey = str(contact.get("public_key", "")).lower()
+    node_id = mc_id_from_full_pubkey(pubkey) if pubkey else "mc:unknown"
+    adv_name = str(contact.get("adv_name", "") or "").strip()
+    long_name = adv_name or f"meshcore:{pubkey[:8]}"
+    short_name = (adv_name[:4] if adv_name else pubkey[:4]) or "????"
+    user = MeshNode.User(
+        node_id=node_id,
+        long_name=long_name,
+        short_name=short_name,
+        macaddr="",
+        hw_model="MESHCORE",
+        public_key=pubkey,
+    )
+    node = MeshNode()
+    node.user = user
+    node.position = None
+    node.device_metrics = None
+    node.is_favorite = False
+    return node
+
+
+def event_to_node_update(event: Event) -> Optional[NodeUpdate]:
+    """Advert / contact events that should refresh the local node DB."""
+    if event.type == EventType.ADVERTISEMENT:
+        payload = event.payload if isinstance(event.payload, dict) else {}
+        pk = str(payload.get("public_key", ""))
+        if not pk:
+            return None
+        node = MeshNode()
+        node.user = MeshNode.User(
+            node_id=mc_id_from_full_pubkey(pk),
+            long_name=f"meshcore:{pk[:8]}",
+            short_name=pk[:4],
+            macaddr="",
+            hw_model="MESHCORE",
+            public_key=pk.lower(),
+        )
+        node.position = None
+        node.device_metrics = None
+        node.is_favorite = False
+        return NodeUpdate(
+            node=node,
+            last_heard=datetime.now(timezone.utc),
+            raw=_raw_envelope(event),
+        )
+
+    if event.type in (EventType.NEW_CONTACT, EventType.NEXT_CONTACT):
+        payload = event.payload if isinstance(event.payload, dict) else {}
+        if "public_key" not in payload:
+            return None
+        node = _contact_payload_to_node(payload)
+        return NodeUpdate(
+            node=node,
+            last_heard=datetime.now(timezone.utc),
+            raw=_raw_envelope(event),
+        )
+
+    return None
+
+
+def _raw_envelope(event: Event) -> dict[str, Any]:
+    """Opaque dict for the bot / dumps — not Meshtastic-shaped."""
+    return {
+        "meshcore": True,
+        "type": event.type.value,
+        "payload": event.payload,
+        "attributes": dict(event.attributes) if event.attributes else {},
+    }

--- a/test/meshcore/__init__.py
+++ b/test/meshcore/__init__.py
@@ -1,0 +1,1 @@
+# MeshCore adapter tests

--- a/test/meshcore/test_dump.py
+++ b/test/meshcore/test_dump.py
@@ -1,0 +1,23 @@
+"""Tests for :mod:`src.meshcore.dump`."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.meshcore.dump import dump_meshcore_event
+
+
+def test_dump_meshcore_event_writes_protocol_marker(tmp_path: Path) -> None:
+    path = dump_meshcore_event(
+        event_type="contact_message",
+        payload={"text": "hi", "pubkey_prefix": "aabbccddeeff"},
+        attributes={"txt_type": 1},
+        base_dir=tmp_path,
+    )
+    assert path is not None
+    assert path.exists()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["protocol"] == "meshcore"
+    assert data["event_type"] == "contact_message"
+    assert data["payload"]["pubkey_prefix"] == "aabbccddeeff"

--- a/test/meshcore/test_radio.py
+++ b/test/meshcore/test_radio.py
@@ -1,0 +1,61 @@
+"""Tests for :mod:`src.meshcore.radio` dispatch path."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from meshcore.events import Event, EventType
+
+from src.meshcore.radio import MeshCoreRadio
+from src.radio.events import IncomingPacket, IncomingTextMessage, NodeUpdate
+from src.radio.interface import RadioHandlers
+
+
+def test_meshcore_radio_dispatch_round_trip(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("MESHCORE_DUMP_ENABLED", "true")
+    received: list[tuple[str, object]] = []
+
+    def on_packet(p: IncomingPacket) -> None:
+        received.append(("packet", p))
+
+    def on_text(t: IncomingTextMessage) -> None:
+        received.append(("text", t))
+
+    def on_node(u: NodeUpdate) -> None:
+        received.append(("node", u))
+
+    radio = MeshCoreRadio(serial_device="/dev/null-not-used", data_dir=tmp_path)
+    radio.set_handlers(
+        RadioHandlers(
+            on_packet=on_packet,
+            on_text_message=on_text,
+            on_node_update=on_node,
+        )
+    )
+    radio._local_node_id = "mc:testlocal12"
+
+    ev = Event(
+        EventType.CONTACT_MSG_RECV,
+        {
+            "type": "PRIV",
+            "pubkey_prefix": "aabbccddeeff",
+            "text": "!ping",
+        },
+        {},
+    )
+    radio.dispatch_meshcore_event_for_tests(ev)
+
+    assert (tmp_path / "meshcore_packets" / "contact_message").exists()
+    json_files = list((tmp_path / "meshcore_packets" / "contact_message").glob("*.json"))
+    assert len(json_files) == 1
+    kinds = [k for k, _ in received]
+    assert "packet" in kinds
+    assert "text" in kinds
+
+
+def test_meshcore_radio_invalid_transport_raises() -> None:
+    with pytest.raises(ValueError):
+        MeshCoreRadio(serial_device=None, ble_address=None)
+    with pytest.raises(ValueError):
+        MeshCoreRadio(serial_device="/dev/ttyUSB0", ble_address="AA:BB:CC:DD:EE:FF")

--- a/test/meshcore/test_serializers.py
+++ b/test/meshcore/test_serializers.py
@@ -1,0 +1,20 @@
+"""Tests for :mod:`src.meshcore.serializers`."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.data_classes import MeshNode
+from src.meshcore.serializers import MeshCorePacketSerializer
+
+
+def test_meshcore_packet_serializer_stub() -> None:
+    ser = MeshCorePacketSerializer()
+    with pytest.raises(NotImplementedError):
+        ser.serialise_raw_packet({})
+    with pytest.raises(NotImplementedError):
+        node = MeshNode()
+        node.user = MeshNode.User()
+        ser.serialise_node(node)
+    with pytest.raises(NotImplementedError):
+        ser.deserialise_node({})

--- a/test/meshcore/test_translation.py
+++ b/test/meshcore/test_translation.py
@@ -1,0 +1,112 @@
+"""Tests for :mod:`src.meshcore.translation`."""
+
+from __future__ import annotations
+
+from meshcore.events import Event, EventType
+
+from src.meshcore.translation import (
+    event_to_incoming_packet,
+    event_to_node_update,
+    event_to_text_message,
+    mc_id_from_full_pubkey,
+    mc_id_from_prefix,
+)
+
+
+def test_mc_ids() -> None:
+    assert mc_id_from_prefix("AABBCCDDEEFF") == "mc:p:aabbccddeeff"
+    assert mc_id_from_full_pubkey("AB" * 32) == "mc:" + "ab" * 32
+
+
+def test_contact_message_to_packet_and_text() -> None:
+    ev = Event(
+        EventType.CONTACT_MSG_RECV,
+        {
+            "type": "PRIV",
+            "pubkey_prefix": "112233445566",
+            "text": "!help",
+            "channel_idx": 0,
+        },
+        {"pubkey_prefix": "112233445566"},
+    )
+    pkt = event_to_incoming_packet(ev)
+    assert pkt is not None
+    assert pkt.portnum == "MC_CONTACT_MSG_RECV"
+    assert pkt.from_id == "mc:p:112233445566"
+    txt = event_to_text_message(ev, local_node_id="mc:localnode12")
+    assert txt is not None
+    assert txt.is_dm is True
+    assert txt.to_id == "mc:localnode12"
+
+
+def test_channel_message_placeholder_ids() -> None:
+    ev = Event(
+        EventType.CHANNEL_MSG_RECV,
+        {
+            "type": "CHAN",
+            "channel_idx": 2,
+            "text": "hello mesh",
+        },
+        {"channel_idx": 2},
+    )
+    pkt = event_to_incoming_packet(ev)
+    assert pkt is not None
+    assert pkt.from_id == "mc:channel:2:rx"
+    txt = event_to_text_message(ev, local_node_id="mc:self")
+    assert txt is not None
+    assert txt.is_dm is False
+    assert txt.from_id == "mc:channel:2:rx"
+
+
+def test_advertisement_node_update() -> None:
+    pk = "aa" * 32
+    ev = Event(EventType.ADVERTISEMENT, {"public_key": pk})
+    upd = event_to_node_update(ev)
+    assert upd is not None
+    assert upd.node.user.id == f"mc:{pk}"
+
+
+def test_path_update_incoming_packet() -> None:
+    pk = "bb" * 32
+    ev = Event(EventType.PATH_UPDATE, {"public_key": pk})
+    pkt = event_to_incoming_packet(ev)
+    assert pkt is not None
+    assert pkt.from_id == f"mc:{pk}"
+
+
+def test_ack_battery_raw_messages_waiting() -> None:
+    assert event_to_incoming_packet(Event(EventType.ACK, {"code": "01020304"})) is not None
+    bat = event_to_incoming_packet(Event(EventType.BATTERY, {"level": 85}))
+    assert bat is not None
+    assert bat.is_self_telemetry is True
+    assert event_to_incoming_packet(Event(EventType.RAW_DATA, {"SNR": 1.0, "RSSI": -90})) is not None
+    assert event_to_incoming_packet(Event(EventType.MESSAGES_WAITING, {})) is not None
+
+
+def test_self_info_and_device_info() -> None:
+    pk = "cc" * 32
+    self_ev = Event(EventType.SELF_INFO, {"public_key": pk})
+    pkt = event_to_incoming_packet(self_ev)
+    assert pkt is not None
+    assert pkt.from_id == f"mc:{pk}"
+    dev = event_to_incoming_packet(Event(EventType.DEVICE_INFO, {"model": "X"}))
+    assert dev is not None
+    assert dev.from_id is None
+
+
+def test_new_contact_node_update() -> None:
+    pk = "dd" * 32
+    ev = Event(
+        EventType.NEW_CONTACT,
+        {
+            "public_key": pk,
+            "adv_name": "TestNode",
+        },
+    )
+    upd = event_to_node_update(ev)
+    assert upd is not None
+    assert upd.node.user.long_name == "TestNode"
+
+
+def test_unknown_event_returns_no_packet() -> None:
+    assert event_to_incoming_packet(Event(EventType.ERROR, {"reason": "x"})) is None


### PR DESCRIPTION
# Summary

Phase **0.3** of the MeshCore adoption plan: add capture-only MeshCore connectivity to `meshflow-bot`. The bot can now run against either Meshtastic (TCP, full upload + WS as today) or MeshCore (USB serial / BLE, local JSON capture only) by setting `RADIO_PROTOCOL`. No `meshflow-api` changes are required and no new outbound HTTP traffic is introduced for MeshCore.

This sets us up to do §0.4 — a multi-day capture campaign against a real Scottish-Mesh feeder — before we design the Phase 1 ingest schema.

## Background

- Meshtastic and MeshCore are both LoRa mesh ecosystems we want first-class support for. The plan introduces a `protocol` discriminator across api/bot/ui; this PR is the bot-side beachhead.
- `meshcore_py` is `asyncio`-native, while the bot's `RadioInterface` (introduced in §0.2 / `bot-80`) is sync. We bridge them by running `meshcore` on a dedicated asyncio loop in a background thread inside `MeshCoreRadio` and posting events back through the same `RadioHandlers` callbacks the Meshtastic adapter already uses — the bot core stays unchanged.
- MeshCore identifies nodes by 32-byte Ed25519 public keys (not 32-bit `nodenum`), so the existing `local_nodenum` is exposed as `None` and `local_node_id` becomes `mc:<first-12-hex-of-pubkey>` (or `mc:p:<6-byte-prefix>` when only a sender prefix is on the wire).
- Capture-only is deliberate: no MC ingest endpoint exists yet (Phase 1.4). Running against a live radio gives us recorded events to validate the Phase 1 schema decisions against real data.

## What's in this PR

### New `src/meshcore/` adapter

- `src/meshcore/radio.py` — `MeshCoreRadio(RadioInterface)`:
  - Constructor enforces "exactly one of `serial_device` or `ble_address`".
  - `connect()` starts a daemon thread that owns its own `asyncio` loop, runs `MeshCore.create_serial(...)` or `MeshCore.create_ble(...)` with `auto_reconnect=True`, subscribes to **all** `EventType`s via a single dispatcher, calls `start_auto_message_fetching()`, and records `local_node_id` from `SELF_INFO` (or `meshcore.self_info`).
  - Errors during startup propagate back to the caller via a `threading.Event` + `_startup_error`, so the bot's `connect()` still raises like it does today.
  - `disconnect()` is idempotent: it signals shutdown, schedules `meshcore.disconnect()` on the loop, joins the thread, and clears state.
  - `send_text` / `send_reaction` / `send_traceroute` raise `RadioError("MeshCore send not implemented in 0.3 capture-only mode")` — Phase 1.4 lifts this.
  - `dispatch_meshcore_event_for_tests()` lets the tests exercise the synchronous tail of the dispatch path without spinning up an asyncio loop.
- `src/meshcore/translation.py` — pure functions:
  - `event_to_incoming_packet(event)` synthesises a stable `MC_<EVENT_NAME>` portnum and maps `CONTACT_MSG_RECV`, `CHANNEL_MSG_RECV`, `ADVERTISEMENT`, `PATH_UPDATE`, `ACK`, `BATTERY`, `RAW_DATA`, `MESSAGES_WAITING`, `SELF_INFO`, `DEVICE_INFO`. Other event types return `None` (still get dumped, not surfaced as packets).
  - `event_to_text_message(event, local_node_id=...)` for `*_MSG_RECV`, populating `from_id` from `pubkey_prefix`, channel index from `channel_idx`, and `is_dm` from `type == "PRIV"`. Channel frames lack a sender pubkey today, so we use a stable placeholder id `mc:channel:<idx>:rx`.
  - `event_to_node_update(event)` for `ADVERTISEMENT`, `NEW_CONTACT`, `NEXT_CONTACT` so the existing node DB / `node_info` book-keeping populates without changes.
- `src/meshcore/dump.py` — writes one JSON file per event under `data/meshcore_packets/<event_type>/<UTC-timestamp>.json` with `protocol: "meshcore"`, `event_type`, `payload`, `attributes`. `bytes` payloads are hex-encoded; non-JSON values fall back to `str()`. Gated by `MESHCORE_DUMP_ENABLED` (default on); high-frequency `no_more_messages` and `command_ok` are intentionally skipped from disk dumps but still flow through handlers.
- `src/meshcore/serializers.py` — `MeshCorePacketSerializer` is a deliberate `NotImplementedError` stub so the §1.4 wiring only has to fill the methods, not change `main.py`.

### Wiring (`main.py`, `bot.py`, env)

- `src/main.py` `build_radio(data_dir)` now branches on `RADIO_PROTOCOL`:
  - `meshtastic` (default): unchanged — `MeshtasticRadio` + `MeshtasticPacketSerializer` + `StorageAPIWrapper` + `MeshflowWSClient`.
  - `meshcore`: builds `MeshCoreRadio` (serial or BLE, baud, debug, data_dir all from env). `STORAGE_API_*` and the WS client are skipped with a one-line info log so a misconfigured deploy fails loud rather than silently uploading garbage.
- `src/bot.py` `_on_packet`: the existing `dump_packet` only fires for Meshtastic-shaped dicts (`"decoded"` key); MeshCore raw events use a `meshcore: True` envelope and are dumped under `data/meshcore_packets/` by the adapter.
- `.env.example` gains a commented MeshCore block (`MESHCORE_SERIAL_DEVICE`, `MESHCORE_BLE_ADDRESS`, `MESHCORE_BLE_PIN`, `MESHCORE_DUMP_ENABLED`, `MESHCORE_DEBUG`).

### Docker

- `docker-compose.yaml`:
  - **Renamed** the existing service `meshtastic-bot` → `meshflow-bot-meshtastic`, container name updated to match, image changed to `ghcr.io/pskillen/meshflow-bot:latest` (legacy `ghcr.io/pskillen/meshtastic-bot` reference dropped).
  - **Added** a sibling `meshflow-bot-meshcore` service: same image, `RADIO_PROTOCOL=meshcore`, USB pass-through (`devices: /dev/ttyUSB0:/dev/ttyUSB0`), with a commented BLE example. Data lives in `./data-meshcore` so MC captures don't collide with the MT bot.
  - Watchtower now watches both services.

### Documentation

- New `docs/MESHCORE.md` — overview, transports table, env vars table, identity model (pubkey, not nodenum), capture layout, run instructions (native + compose), Phase 0.3 / 1.x scope.
- New `docs/MESHTASTIC.md` — extracted Meshtastic-specific config from the old README (env vars, API upload, WS commands, `IGNORE_PORTNUMS`, `DUMP_PACKETS_PORTNUMS`, sample fixtures).
- `README.md` is now protocol-neutral: it links to both per-protocol docs and shows both compose services.
- `AGENTS.md` refreshed: project-structure tree, key concepts, and conventions cover both protocols (Meshtastic `!hex8` / decimal nodenum vs MeshCore `mc:` pubkey ids and `local_nodenum=None`).

### Tests

Under `test/meshcore/`:

- `test_dump.py` — dumps an event into `tmp_path` and asserts the `protocol: "meshcore"` marker plus payload round-trip.
- `test_translation.py` — covers the id helpers, `CONTACT_MSG_RECV` (DM path), `CHANNEL_MSG_RECV` (placeholder id path), `ADVERTISEMENT` / `NEW_CONTACT` node updates, and the `ACK` / `BATTERY` / `RAW_DATA` / `MESSAGES_WAITING` / `SELF_INFO` / `DEVICE_INFO` / `PATH_UPDATE` packet mappings, plus the "unknown event ⇒ no packet" branch.
- `test_radio.py` — drives `MeshCoreRadio.dispatch_meshcore_event_for_tests` with a fake `Event`, asserts the JSON dump file is written under `data/meshcore_packets/contact_message/`, that handlers see both `IncomingPacket` and `IncomingTextMessage`, and that constructing the radio with neither / both transports raises.
- `test_serializers.py` — locks in the deliberate `NotImplementedError` on the stub serializer.

## What this PR deliberately does NOT do

- No `meshflow-api` changes; no MC ingest endpoint; no upload from the bot.
- No outbound send over MeshCore (text, reactions, traceroute) — `RadioError` for now.
- No business-model normalisation, mesh-monitoring, weather, RF, or DX integration for MeshCore.
- No MC-specific commands or responders. `!help`, `!ping`, etc. work over MC channel/contact frames already because the bot core is protocol-agnostic, but reply paths require Phase 1.4.

## Testing performed

- `pytest test/ --doctest-modules` — **146 passed, 1 skipped**, coverage **72.31%** (gate is 70%). Existing Meshtastic tests unchanged.
- `docker compose config -q` — clean.
- Smoke-imported the new modules under Python 3.14 to make sure `meshcore==2.3.7` resolves and `EventType.SELF_INFO` is the right enum member.
- Manual smoke (operator-led, NOT gated in CI) is the §0.3 acceptance criterion in the plan: run `RADIO_PROTOCOL=meshcore MESHCORE_SERIAL_DEVICE=/dev/ttyUSB0 python -m src.main` against a live MeshCore companion radio for several minutes; expect `connection established`, JSON files appearing under `data/meshcore_packets/<event_type>/`, and zero outbound HTTP. Captured samples feed §0.4.

## Follow-ups (not this PR)

- §0.4 — multi-day capture campaign + `MESHCORE_PACKET_FIELDS.md` against real data.
- §0.5 — ADRs locking in MC node identity, channel modelling, broadcast semantics, dedup tuple.
- §1.x — `meshcore_packets` Django app, `POST /api/meshcore/packets/{id}/ingest/`, and `MESHCORE_UPLOAD_ENABLED` flipped on in the bot.
