### PR TITLE
chore(ci): add Dependabot grouped weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,56 @@
+# Dependabot — tracked in https://github.com/pskillen/meshflow-ui/issues/59
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Europe/London
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      python-app-and-dev:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Europe/London
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Europe/London
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      docker:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` for weekly grouped pip (app + dev), GitHub Actions, and Docker updates.
- Schedule: Mondays 09:00 Europe/London.

Tracked by [meshflow-ui#59](https://github.com/pskillen/meshflow-ui/issues/59).

## Related PRs

- meshflow-ui
- meshflow-api
- meshflow-rf-propagation

## Testing performed

- Config only; no application code changes.