### PR TITLE
docs(meshcore): SP-02 comment-only protocol labelling (#309)

### DIFF
--- a/src/api/StorageAPI.py
+++ b/src/api/StorageAPI.py
@@ -1,8 +1,14 @@
 """HTTP client for the meshflow-api ingest endpoints.
 
-Protocol-agnostic: takes a :class:`PacketSerializer` to shape outgoing data,
-and a ``local_nodenum_provider`` callable so it can lazily look up the local
-nodenum for v2 endpoints (which are scoped per-node).
+Meshtastic uploads use v2 paths scoped by local nodenum:
+``POST /api/packets/{nodenum}/ingest/`` and ``…/nodes/`` (see ``_get_url`` when
+``api_version == 2``). v1 ``POST /api/raw-packet/`` is legacy.
+
+MeshCore uploads use ``POST /api/meshcore/packets/ingest/`` via
+:meth:`store_raw_meshcore_packet` (not the Meshtastic packet paths).
+
+Takes a :class:`PacketSerializer` to shape outgoing data and a
+``local_nodenum_provider`` for Meshtastic v2 URL construction.
 """
 
 from __future__ import annotations
@@ -109,9 +115,10 @@ class StorageAPIWrapper(BaseAPIWrapper):
         return None
 
     def store_raw_packet(self, packet: Any) -> Optional[dict]:
-        """Sanitise and upload a received packet. Returns the api response or
-        ``None`` if upload failed; never raises (errors are dumped to disk
-        when ``failed_packets_dir`` is configured)."""
+        """Sanitise and upload a Meshtastic packet to v2 ``/api/packets/{nodenum}/ingest/``
+        (or v1 ``/api/raw-packet/``). Returns the api response or ``None`` if upload failed;
+        never raises (errors are dumped to disk when ``failed_packets_dir`` is configured).
+        For MeshCore captures use :meth:`store_raw_meshcore_packet` instead."""
         try:
             payload = self._serializer.serialise_raw_packet(packet)
         except Exception as exc:

--- a/src/radio/events.py
+++ b/src/radio/events.py
@@ -17,13 +17,18 @@ class IncomingPacket:
     """A packet received from the radio, in protocol-agnostic form."""
 
     portnum: str
-    """Portnum / message-type as an upper-case string (e.g. ``TEXT_MESSAGE_APP``)."""
+    """Portnum / message-type as an upper-case string (e.g. ``TEXT_MESSAGE_APP``).
+
+    Meshtastic-specific today; MeshCore adapters map native payload types to a
+    comparable label for logging and routing.
+    """
 
     from_id: Optional[str]
-    """Sender node id in canonical hex form (``!aabbccdd``) or ``None`` if unknown."""
+    """Sender node id in canonical form (``!aabbccdd`` Meshtastic, ``mc:deadbeefcafe`` MeshCore)
+    or ``None`` if unknown."""
 
     to_id: Optional[str]
-    """Destination node id, or ``None`` for unaddressed broadcasts."""
+    """Destination node id (same canonical forms as ``from_id``), or ``None`` for broadcasts."""
 
     channel: int = 0
 
@@ -54,7 +59,11 @@ class IncomingTextMessage:
     channel: int = 0
     message_id: int = 0
     hop_start: int = 0
+    """Meshtastic hop budget at send (MeshCore adapters may leave 0)."""
+
     hop_limit: int = 0
+    """Meshtastic hops remaining at receive (MeshCore adapters may leave 0)."""
+
     is_dm: bool = False
     raw: Any = None
     """The protocol-native packet that produced this message, kept opaque

--- a/src/radio/interface.py
+++ b/src/radio/interface.py
@@ -11,12 +11,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Callable, Optional
 
-from src.radio.events import (
-    ConnectionEstablished,
-    IncomingPacket,
-    IncomingTextMessage,
-    NodeUpdate,
-)
+from src.radio.events import (ConnectionEstablished, IncomingPacket,
+                              IncomingTextMessage, NodeUpdate)
 
 
 @dataclass
@@ -75,7 +71,10 @@ class RadioInterface(ABC):
     @property
     @abstractmethod
     def local_nodenum(self) -> Optional[int]:
-        """Local node id as an unsigned int, or ``None`` pre-connect."""
+        """Meshtastic local node id as an unsigned int, or ``None`` pre-connect.
+
+        MeshCore radios return ``None``; use ``local_node_id`` (``mc:…``) instead.
+        """
 
     # --- send-side ---------------------------------------------------------
 
@@ -113,8 +112,8 @@ class RadioInterface(ABC):
         *,
         channel_index: int = 0,
     ) -> None:
-        """Send a protocol-appropriate traceroute / route-discovery probe.
+        """Send a Meshtastic traceroute (``target_node_id`` is numeric nodenum).
 
-        Adapters that don't support traceroute should raise
+        MeshCore and other adapters that do not support traceroute should raise
         :class:`~src.radio.errors.RadioError`.
         """


### PR DESCRIPTION
## Summary

SP-02 (#309): docstrings clarifying Meshtastic vs MeshCore ingest paths and radio event shapes.

- `src/radio/events.py`: `portnum`, `from_id`/`to_id` (`!…` and `mc:…`), hop fields
- `src/radio/interface.py`: `local_nodenum` and `send_traceroute` Meshtastic-only
- `src/api/StorageAPI.py`: v2 `/api/packets/{n}/ingest/` vs `/api/meshcore/packets/ingest/`

Related: [meshflow-api#321](https://github.com/pskillen/meshflow-api/pull/321), [meshflow-ui#267](https://github.com/pskillen/meshflow-ui/pull/267)

Part of #309 (tracking issue on meshflow-api).

## Testing performed

- `black` / `isort` on changed files
- Doc-only; no behaviour change