### PR TITLE
docs: Cursor agent git Shell working_directory guidance

### DIFF
--- a/.cursor/skills/meshflow-git-workflow/SKILL.md
+++ b/.cursor/skills/meshflow-git-workflow/SKILL.md
@@ -112,7 +112,26 @@ refactor(storage): extract packet parsing into service
 
 ---
 
-## 5. Pull Requests
+## 5. Running git in Cursor agents
+
+When the agent **Shell** tool runs `git` (or other commands) in a Meshflow repo:
+
+1. **Always set `working_directory`** to the repository root (absolute path), e.g. `/Users/you/git_personal/meshflow-bot`. Commands that only `cd` inside the command string often return **empty output** even when they succeed (exit code 0).
+
+2. **Good pattern**
+
+   ```text
+   working_directory: /Users/you/git_personal/meshflow-bot
+   command:            git fetch origin && git status -sb
+   ```
+
+3. **Permissions**: use `required_permissions: ["git_write"]` for checkout/commit; add `"network"` for `fetch` / `push`.
+
+4. **PRs and issues**: use the `github-personal` MCP. The `gh` CLI is not available on Meshflow dev machines.
+
+---
+
+## 6. Pull Requests
 
 When the work is done:
 
@@ -131,5 +150,5 @@ When the work is done:
 | Plan | Issue in relevant repo(s); parent in meshflow-api if multi-repo |
 | Branch | `{issue-repo-prefix}-{num}/{author}/{description}` (prefix = repo where the issue lives) |
 | Pre-commit | meshflow-api/meshtastic-bot: venv + black, isort, flake8; meshtastic-bot-ui: `npm run format` |
-| Commit | Conventional commits, no "enhance" |
+| Commit | Conventional commits, no "enhance"; Shell `working_directory` = repo root |
 | PR | Open in all affected repos, link issues and related PRs |


### PR DESCRIPTION
## Summary

Document that Cursor agents must set Shell `working_directory` to the repo root for reliable `git` output.

## Testing performed

- [x] Docs only