### PR TITLE
refactor(bot): Meshtastic-local naming in storage and node DB (SP-10)

### DIFF
--- a/src/api/StorageAPI.py
+++ b/src/api/StorageAPI.py
@@ -8,7 +8,7 @@ MeshCore uploads use ``POST /api/meshcore/packets/ingest/`` via
 :meth:`store_raw_meshcore_packet` (not the Meshtastic packet paths).
 
 Takes a :class:`PacketSerializer` to shape outgoing data and a
-``local_nodenum_provider`` for Meshtastic v2 URL construction.
+``local_meshtastic_nodenum_provider`` for Meshtastic v2 URL construction.
 """
 
 from __future__ import annotations
@@ -45,7 +45,7 @@ class StorageAPIWrapper(BaseAPIWrapper):
         failed_packets_dir: Optional[Union[str, Path]] = None,
         *,
         serializer: PacketSerializer,
-        local_nodenum_provider: Callable[[], Optional[int]],
+        local_meshtastic_nodenum_provider: Callable[[], Optional[int]],
     ):
         super().__init__(base_url, token)
         self.api_version = api_version
@@ -53,7 +53,7 @@ class StorageAPIWrapper(BaseAPIWrapper):
             Path(failed_packets_dir) if failed_packets_dir else None
         )
         self._serializer = serializer
-        self._local_nodenum_provider = local_nodenum_provider
+        self._local_meshtastic_nodenum_provider = local_meshtastic_nodenum_provider
         self._error_counter = get_global_error_counter()
 
     def _get_url(self, path: str, args: Optional[dict] = None) -> str:
@@ -67,7 +67,7 @@ class StorageAPIWrapper(BaseAPIWrapper):
                 "node_by_id": f"/api/nodes/{args.get('node_id', '')}",
             }
         else:
-            local_nodenum = self._local_nodenum_provider()
+            local_nodenum = self._local_meshtastic_nodenum_provider()
             api_paths = {
                 "raw_packet": f"/api/packets/{local_nodenum}/ingest/",
                 "nodes": f"/api/packets/{local_nodenum}/nodes/",

--- a/src/bot.py
+++ b/src/bot.py
@@ -151,7 +151,7 @@ class MeshflowBot:
         if not sender:
             return
 
-        node = self.node_db.get_by_id(sender)
+        node = self.node_db.get_by_radio_id(sender)
         if not node:
             return
 
@@ -160,7 +160,7 @@ class MeshflowBot:
             self.node_info.node_packet_received(sender, event.portnum)
 
         if sender == self.my_id and event.to_id is not None:
-            recipient = self.node_db.get_by_id(event.to_id)
+            recipient = self.node_db.get_by_radio_id(event.to_id)
             recipient_name = recipient.long_name if recipient else event.to_id
             logger.debug(
                 "Received packet from self: %s (port %s)", recipient_name, event.portnum
@@ -194,7 +194,7 @@ class MeshflowBot:
     # --- private message dispatch ----------------------------------------
 
     def _handle_private_message(self, message: IncomingTextMessage) -> None:
-        sender = self.node_db.get_by_id(message.from_id)
+        sender = self.node_db.get_by_radio_id(message.from_id)
         sender_name = sender.long_name if sender else message.from_id
         logger.info("Received private message: '%s' from %s", message.text, sender_name)
 
@@ -228,7 +228,7 @@ class MeshflowBot:
             counter=self._error_counter,
         )
         if outcome:
-            sender = self.node_db.get_by_id(message.from_id)
+            sender = self.node_db.get_by_radio_id(message.from_id)
             sender_name = sender.long_name if sender else message.from_id
             logger.info(
                 "Handled message from %s with responder %s: %s",
@@ -250,7 +250,7 @@ class MeshflowBot:
         for node_id in sorted_nodes:
             if node_id == self.my_id:
                 continue
-            node = self.node_db.get_by_id(node_id)
+            node = self.node_db.get_by_radio_id(node_id)
             last_heard = self.node_info.get_last_heard(node_id)
             last_heard_str = pretty_print_last_heard(last_heard)
             encoded_name = safe_encode_node_name(node.long_name) if node else node_id

--- a/src/commands/admin.py
+++ b/src/commands/admin.py
@@ -21,7 +21,7 @@ class AdminCommand(AbstractCommandWithSubcommands):
     def handle_packet(self, message: IncomingTextMessage) -> None:
         sender = message.from_id
         if sender not in self.bot.admin_nodes:
-            node = self.bot.node_db.get_by_id(sender)
+            node = self.bot.node_db.get_by_radio_id(sender)
             response = (
                 f"Sorry {node.long_name}, you are not authorized to use this command"
             )
@@ -132,7 +132,7 @@ class AdminCommand(AbstractCommandWithSubcommands):
 
         response = f"Users: {len(user_ids)}\n"
         for user_id in user_ids:
-            node = self.bot.node_db.get_by_id(user_id)
+            node = self.bot.node_db.get_by_radio_id(user_id)
             user_name = node.short_name if node else f"Unknown user {user_id}"
             known_request_count = len(_rows_for_sender(command_history, user_id))
             unknown_request_count = len(

--- a/src/commands/hello.py
+++ b/src/commands/hello.py
@@ -9,7 +9,7 @@ class HelloCommand(AbstractCommand):
 
     def handle_packet(self, message: IncomingTextMessage) -> None:
         sender_id = message.from_id
-        sender = self.bot.node_db.get_by_id(sender_id)
+        sender = self.bot.node_db.get_by_radio_id(sender_id)
         sender_name = sender.long_name if sender else sender_id
 
         response = (

--- a/src/commands/nodes.py
+++ b/src/commands/nodes.py
@@ -78,7 +78,7 @@ class NodesCommand(AbstractCommandWithSubcommands):
         self.reply_to(sender, response)
 
     def send_detailed_nodeinfo(self, sender: str, node_id: str) -> None:
-        node = self.bot.node_db.get_by_id(node_id)
+        node = self.bot.node_db.get_by_radio_id(node_id)
         if not node:
             return
 

--- a/src/commands/template.py
+++ b/src/commands/template.py
@@ -20,7 +20,7 @@ class TemplateCommand(AbstractCommand):
         if not text.startswith(f"!{self.base_command}"):
             return
 
-        sender = self.bot.node_db.get_by_id(sender_id)
+        sender = self.bot.node_db.get_by_radio_id(sender_id)
 
         template = Template(self.template)
         local_context = {

--- a/src/data_classes.py
+++ b/src/data_classes.py
@@ -25,7 +25,11 @@ class MeshNode:
             macaddr: str = "",
             hw_model: str = "",
             public_key: str = "",
+            *,
+            canonical_id: str | None = None,
         ):
+            if canonical_id is not None:
+                node_id = canonical_id
             self.id = node_id
             self.long_name = long_name
             self.short_name = short_name

--- a/src/main.py
+++ b/src/main.py
@@ -128,7 +128,7 @@ def main() -> None:
                 STORAGE_API_VERSION,
                 failed_packets_dir,
                 serializer=serializer,
-                local_nodenum_provider=lambda: bot.my_nodenum,
+                local_meshtastic_nodenum_provider=lambda: bot.my_nodenum,
             )
         )
     elif STORAGE_API_ROOT and RADIO_PROTOCOL == "meshcore" and MESHCORE_UPLOAD_ENABLED:
@@ -139,7 +139,7 @@ def main() -> None:
                 api_version=2,
                 failed_packets_dir=failed_packets_dir,
                 serializer=serializer,
-                local_nodenum_provider=lambda: bot.my_nodenum,
+                local_meshtastic_nodenum_provider=lambda: bot.my_nodenum,
             )
         )
     elif STORAGE_API_ROOT and RADIO_PROTOCOL == "meshcore":
@@ -154,7 +154,7 @@ def main() -> None:
                 STORAGE_API_2_VERSION,
                 failed_packets_dir,
                 serializer=serializer,
-                local_nodenum_provider=lambda: bot.my_nodenum,
+                local_meshtastic_nodenum_provider=lambda: bot.my_nodenum,
             )
         )
     elif (
@@ -167,7 +167,7 @@ def main() -> None:
                 STORAGE_API_2_VERSION,
                 failed_packets_dir,
                 serializer=serializer,
-                local_nodenum_provider=lambda: bot.my_nodenum,
+                local_meshtastic_nodenum_provider=lambda: bot.my_nodenum,
             )
         )
     elif STORAGE_API_2_ROOT and RADIO_PROTOCOL == "meshcore":

--- a/src/persistence/node_db.py
+++ b/src/persistence/node_db.py
@@ -16,7 +16,7 @@ class AbstractNodeDB(abc.ABC):
             self.store_device_metrics(node.user.id, node.device_metrics)
 
     @abc.abstractmethod
-    def get_by_id(self, node_id: str) -> MeshNode.User | None:
+    def get_by_radio_id(self, node_id: str) -> MeshNode.User | None:
         pass
 
     @abc.abstractmethod
@@ -79,7 +79,7 @@ class InMemoryNodeDB(AbstractNodeDB):
             self.device_metrics[node_id] = []
         self.device_metrics[node_id].append(device_metrics)
 
-    def get_by_id(self, node_id: str) -> MeshNode.User | None:
+    def get_by_radio_id(self, node_id: str) -> MeshNode.User | None:
         return self.nodes.get(node_id)
 
     def get_by_short_name(self, short_name: str) -> MeshNode.User | None:
@@ -185,7 +185,7 @@ class SqliteNodeDB(BaseSqlitePersistenceStore, AbstractNodeDB):
                   device_metrics.channel_utilization, device_metrics.air_util_tx, device_metrics.uptime_seconds))
             conn.commit()
 
-    def get_by_id(self, node_id: str) -> MeshNode.User | None:
+    def get_by_radio_id(self, node_id: str) -> MeshNode.User | None:
         with sqlite3.connect(self.db_path) as conn:
             cursor = conn.cursor()
             cursor.execute('SELECT id, short_name, long_name, macaddr, hw_model, public_key FROM nodes WHERE id = ?',

--- a/test/commands/test_nodes.py
+++ b/test/commands/test_nodes.py
@@ -49,7 +49,7 @@ class TestNodesCommand(CommandWSCTestCase):
 
         expected_response = f"{self.online_count} nodes online.\nBusy nodes:\n"
         for node_id, packet_count in sorted_nodes[:5]:
-            node = self.bot.node_db.get_by_id(node_id)
+            node = self.bot.node_db.get_by_radio_id(node_id)
             expected_response += f"- {node.short_name} ({packet_count} pkts)\n"
 
         last_reset_time = self.bot.node_info.packet_counter_reset_time.strftime("%H:%M:%S")

--- a/test/meshcore/test_storage_upload.py
+++ b/test/meshcore/test_storage_upload.py
@@ -14,7 +14,7 @@ def test_store_raw_meshcore_packet_posts_to_ingest() -> None:
         token="secret",
         api_version=2,
         serializer=MeshCorePacketSerializer(),
-        local_nodenum_provider=lambda: None,
+        local_meshtastic_nodenum_provider=lambda: None,
     )
     envelope = {
         "meshcore": True,

--- a/test/persistence/test_node_db.py
+++ b/test/persistence/test_node_db.py
@@ -17,7 +17,7 @@ class TestInMemoryNodeDB(unittest.TestCase):
 
     def test_store_and_get_user(self):
         self.db.store_user(self.node_user)
-        retrieved_user = self.db.get_by_id(self.node_user.id)
+        retrieved_user = self.db.get_by_radio_id(self.node_user.id)
         self.assertEqual(retrieved_user.id, self.node_user.id)
         self.assertEqual(retrieved_user.short_name, self.node_user.short_name)
         self.assertEqual(retrieved_user.long_name, self.node_user.long_name)
@@ -73,7 +73,7 @@ class TestSqliteNodeDB(unittest.TestCase):
 
     def test_store_and_get_user(self):
         self.db.store_user(self.node_user)
-        retrieved_user = self.db.get_by_id(self.node_user.id)
+        retrieved_user = self.db.get_by_radio_id(self.node_user.id)
         self.assertEqual(retrieved_user.id, self.node_user.id)
         self.assertEqual(retrieved_user.short_name, self.node_user.short_name)
         self.assertEqual(retrieved_user.long_name, self.node_user.long_name)

--- a/test/test_bot_integration.py
+++ b/test/test_bot_integration.py
@@ -67,7 +67,7 @@ class TestMeshflowBotEventRouting(unittest.TestCase):
         node.user = MeshNode.User(node_id="!11112222", long_name="Alice")
         radio.deliver_node_update(NodeUpdate(node=node, last_heard=datetime.now(timezone.utc)))
 
-        self.assertIsNotNone(bot.node_db.get_by_id("!11112222"))
+        self.assertIsNotNone(bot.node_db.get_by_radio_id("!11112222"))
         storage.store_node.assert_called_once_with(node)
 
     def test_text_message_dm_triggers_command(self):


### PR DESCRIPTION
## Summary

- Rename `local_nodenum_provider` → `local_meshtastic_nodenum_provider` on `StorageAPIWrapper`
- Rename `get_by_id` → `get_by_radio_id` on node DB implementations
- Add optional `canonical_id` ctor alias on `MeshNode.User` ([#317](https://github.com/pskillen/meshflow-api/issues/317))

## Testing performed

- [x] `pytest test/ -q` (152 passed)

## Related

Tracked on meshflow-api [#317](https://github.com/pskillen/meshflow-api/issues/317); sub-epic [#307](https://github.com/pskillen/meshflow-api/issues/307).