### PR TITLE
feat(api): report APP_VERSION to meshflow-api on connect

### DIFF
--- a/src/api/BaseAPIWrapper.py
+++ b/src/api/BaseAPIWrapper.py
@@ -33,3 +33,9 @@ class BaseAPIWrapper(ABC):
         response = requests.post(full_url, json=json, headers=self._get_headers())
         response.raise_for_status()
         return response
+
+    def _put(self, url: str, json: dict) -> requests.Response:
+        full_url = f"{self.base_url}/{url.lstrip('/')}"
+        response = requests.put(full_url, json=json, headers=self._get_headers())
+        response.raise_for_status()
+        return response

--- a/src/api/StorageAPI.py
+++ b/src/api/StorageAPI.py
@@ -28,6 +28,7 @@ from src.api.packet_serializer import PacketSerializer
 from src.data_classes import MeshNode
 from src.meshcore.serializers import MeshCoreSkipUpload
 from src.radio.errors import get_global_error_counter
+from src.version import get_bot_version
 
 logger = logging.getLogger(__name__)
 
@@ -71,9 +72,37 @@ class StorageAPIWrapper(BaseAPIWrapper):
             api_paths = {
                 "raw_packet": f"/api/packets/{local_nodenum}/ingest/",
                 "nodes": f"/api/packets/{local_nodenum}/nodes/",
+                "bot_version": f"/api/packets/{local_nodenum}/bot-version/",
                 "node_by_id": f"/api/nodes/{args.get('node_id', '')}",
             }
         return api_paths[path]
+
+    def report_bot_version(self) -> bool:
+        """Report meshflow-bot version (``APP_VERSION``) to the API (v2 path only). Returns True on success."""
+        if self.api_version != 2:
+            logger.debug(
+                "Skipping bot version report (api_version=%s)", self.api_version
+            )
+            return False
+        local_nodenum = self._local_meshtastic_nodenum_provider()
+        if local_nodenum is None:
+            logger.warning("Cannot report bot version: local nodenum not available yet")
+            return False
+        version = get_bot_version()
+        try:
+            self._put(self._get_url("bot_version"), json={"bot_version": version})
+            logger.info("Reported bot version %s to API", version)
+            return True
+        except HTTPError as exc:
+            self._error_counter.increment("storage.report_bot_version.http")
+            logger.error("HTTP error reporting bot version: %s", exc.response.text)
+        except RequestException as exc:
+            self._error_counter.increment("storage.report_bot_version.network")
+            logger.error("Network error reporting bot version: %s", exc)
+        except Exception as exc:
+            self._error_counter.increment("storage.report_bot_version.unexpected")
+            logger.exception("Unexpected error reporting bot version: %s", exc)
+        return False
 
     # --- raw packets ------------------------------------------------------
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -104,6 +104,8 @@ class MeshflowBot:
         logger.info(
             "Connected as %s (nodenum=%s)", event.local_node_id, event.local_nodenum
         )
+        for storage_api in self.storage_apis:
+            storage_api.report_bot_version()
         self.print_nodes()
         if self.ws_client:
             self.ws_client.start()

--- a/src/version.py
+++ b/src/version.py
@@ -1,0 +1,19 @@
+"""Resolve the running meshflow-bot version string for API reporting.
+
+Production images set ``APP_VERSION`` from the Docker ``VERSION`` build arg (see Dockerfile).
+Local runs without that env var default to ``development``, matching meshflow-api settings.
+"""
+
+from __future__ import annotations
+
+import os
+
+_DEFAULT_VERSION = "development"
+
+
+def get_bot_version() -> str:
+    """Return the bot version to report on connect (max 128 chars)."""
+    version = os.environ.get("APP_VERSION", _DEFAULT_VERSION).strip()
+    if not version:
+        version = _DEFAULT_VERSION
+    return version[:128]

--- a/test/test_bot_version_report.py
+++ b/test/test_bot_version_report.py
@@ -1,0 +1,47 @@
+"""Tests for bot version reporting to meshflow-api."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from src.api.StorageAPI import StorageAPIWrapper
+from src.meshtastic.serializers import MeshtasticPacketSerializer
+from src.version import get_bot_version
+
+
+def test_get_bot_version_from_app_version(monkeypatch) -> None:
+    monkeypatch.setenv("APP_VERSION", "  v1.2.3  ")
+    assert get_bot_version() == "v1.2.3"
+
+
+def test_get_bot_version_defaults_to_development(monkeypatch) -> None:
+    monkeypatch.delenv("APP_VERSION", raising=False)
+    assert get_bot_version() == "development"
+
+
+def test_report_bot_version_puts_v2_path() -> None:
+    wrapper = StorageAPIWrapper(
+        "http://api.test",
+        token="secret",
+        api_version=2,
+        serializer=MeshtasticPacketSerializer(),
+        local_meshtastic_nodenum_provider=lambda: 42424242,
+    )
+    mock_response = MagicMock()
+    with patch.object(wrapper, "_put", return_value=mock_response) as put:
+        assert wrapper.report_bot_version() is True
+    put.assert_called_once()
+    assert put.call_args[0][0] == "/api/packets/42424242/bot-version/"
+    assert put.call_args[1]["json"]["bot_version"] == get_bot_version()
+
+
+def test_report_bot_version_skipped_for_v1() -> None:
+    wrapper = StorageAPIWrapper(
+        "http://api.test",
+        api_version=1,
+        serializer=MeshtasticPacketSerializer(),
+        local_meshtastic_nodenum_provider=lambda: 1,
+    )
+    with patch.object(wrapper, "_put") as put:
+        assert wrapper.report_bot_version() is False
+    put.assert_not_called()


### PR DESCRIPTION
## Summary

- `get_bot_version()` reads Docker-injected `APP_VERSION` (`ARG VERSION` in Dockerfile; default `development` locally).
- `StorageAPIWrapper.report_bot_version()` calls v2 `/api/packets/{nodenum}/bot-version/` on radio connect.

Requires meshflow-api PR with the new endpoint and migration deployed first.

**Tracking:** Closes #99

**Related PRs:**
- meshflow-api: `bot-99/pskillen/bot-version-report`
- meshflow-ui: `bot-99/pskillen/bot-version-report`

## Testing performed

- `test/test_bot_version_report.py` (version resolution and URL construction)

Closes #99