### PR TITLE
feat(meshcore): channel sync on connect and WS apply (Phase 2.2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,9 @@ STORAGE_API_VERSION=2
 # Use this if you want to receive commands from the Meshflow server (e.g. traceroute)
 MESHFLOW_WS_URL=ws://localhost:8000
 
+# Log abridged MC/MT packet summaries to the console (default false)
+# LOG_PACKETS=false
+
 # Comma-separated portnums to skip when submitting packets to the API (e.g. custom or rejected ports)
 IGNORE_PORTNUMS=345,ROUTING_APP
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ See [`.env.example`](.env.example), [docs/MESHTASTIC.md](docs/MESHTASTIC.md), an
 - Responders: `src/responders/`, register in `ResponderFactory`.
 - Use `reply_in_channel` / `reply_in_dm` from `AbstractBaseFeature`.
 - Meshtastic node IDs: `!` + 8 hex nibbles; `my_nodenum` is decimal.
-- MeshCore: pubkey-based ids (`mc:...`); `my_nodenum` is `None` for MC.
+- MeshCore: pubkey-based ids (`mc:...`); `my_nodenum` is `0` for API feeder paths (e.g. bot-version).
 
 ## Source control
 

--- a/docs/MESHCORE.md
+++ b/docs/MESHCORE.md
@@ -30,7 +30,16 @@ TCP is supported by `meshcore` but not wired in this bot build (add later if nee
 | `ADMIN_NODES` | Same as Meshtastic: comma-separated admin ids (format may evolve for MC). |
 | `DATA_DIR` | Base data directory (default `data/`). |
 
-Without `MESHCORE_UPLOAD_ENABLED`, `STORAGE_API_*` is ignored. The MeshCore WebSocket command channel is not started (traceroute is Meshtastic-only today).
+Without `MESHCORE_UPLOAD_ENABLED`, `STORAGE_API_*` is ignored.
+
+## Channel sync and WebSocket (Phase 2.2)
+
+When `MESHCORE_UPLOAD_ENABLED=true` and `STORAGE_API_*` are set, the bot also:
+
+1. **On connect** — reads the device channel table (`meshcore.commands.get_channel`) and `POST`s ` /api/meshcore/feeder/mc-channel-sync/` (device is source of truth for names/types).
+2. **WebSocket** — connects to `ws/nodes/?api_key=…` for `apply_mc_channel_config` (UI “apply to radio”); writes channels via `set_channel`, then re-syncs to the API.
+
+Traceroute commands remain Meshtastic-only; MC feeders ignore `traceroute` WS messages.
 
 ## Meshflow upload event types
 

--- a/docs/MESHCORE.md
+++ b/docs/MESHCORE.md
@@ -57,7 +57,7 @@ Map coordinates in the Meshflow UI require **bot** [meshflow-bot#102](https://gi
 MeshCore nodes are identified by **Ed25519 public keys** (64 hex chars), not Meshtastic-style 32-bit node numbers.
 
 - `MeshCoreRadio.local_node_id` is exposed as `mc:` + the first **12** hex characters of the companion’s public key after `SELF_INFO` (or `mc:unknown` if that event is missing).
-- `local_nodenum` is always `None` for MeshCore. `ConnectionEstablished.local_nodenum` is set to `0` as a placeholder for logging only.
+- `local_nodenum` is `0` for MeshCore feeders (matches `ManagedNode.meshtastic_node_id` on the API). Used for feeder-scoped paths such as `PUT /api/packets/0/bot-version/`. Packet ingest uses `/api/meshcore/packets/ingest/` instead.
 
 Remote senders in DMs use ids like `mc:p:<12-hex-prefix>` when only a short prefix is on the wire.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ addopts = [
     "--cov=src",
     "--cov-report=term-missing",
     "--cov-report=xml",
-    "--cov-fail-under=70",
+    "--cov-fail-under=80",
 ]
 
 [tool.coverage.run]
@@ -16,6 +16,8 @@ source = ["src"]
 omit = [
     "src/main.py",
     "src/ws_client.py",
+    "src/meshcore/radio.py",
+    "src/meshtastic/radio.py",
     "src/meshtastic/tcp_interface.py",
     "src/meshtastic/traceroute.py",
 ]

--- a/src/api/StorageAPI.py
+++ b/src/api/StorageAPI.py
@@ -143,6 +143,22 @@ class StorageAPIWrapper(BaseAPIWrapper):
                 self._dump_failed_packet(payload, exc, original_packet=packet)
         return None
 
+    def post_mc_channel_sync(self, body: dict) -> bool:
+        """POST device channel snapshot to ``/api/meshcore/feeder/mc-channel-sync/``."""
+        try:
+            response = self._post("/api/meshcore/feeder/mc-channel-sync/", json=body)
+            return response.status_code in (200, 201)
+        except HTTPError as exc:
+            self._error_counter.increment("storage.post_mc_channel_sync.http")
+            logger.error("HTTP error posting MC channel sync: %s", exc.response.text)
+        except RequestException as exc:
+            self._error_counter.increment("storage.post_mc_channel_sync.network")
+            logger.error("Network error posting MC channel sync: %s", exc)
+        except Exception as exc:
+            self._error_counter.increment("storage.post_mc_channel_sync.unexpected")
+            logger.exception("Unexpected error posting MC channel sync: %s", exc)
+        return False
+
     def store_raw_packet(self, packet: Any) -> Optional[dict]:
         """Sanitise and upload a Meshtastic packet to v2 ``/api/packets/{nodenum}/ingest/``
         (or v1 ``/api/raw-packet/``). Returns the api response or ``None`` if upload failed;

--- a/src/bot.py
+++ b/src/bot.py
@@ -20,6 +20,7 @@ from src.helpers import pretty_print_last_heard, safe_encode_node_name
 from src.persistence.commands_logger import AbstractCommandLogger
 from src.persistence.node_db import AbstractNodeDB
 from src.persistence.node_info import AbstractNodeInfoStore
+from src.packet_log import log_incoming_packet
 from src.persistence.packet_dump import dump_packet
 from src.persistence.user_prefs import AbstractUserPrefsPersistence
 from src.radio.errors import call_safely, get_global_error_counter
@@ -127,11 +128,10 @@ class MeshflowBot:
         )
         for storage_api in self.storage_apis:
             storage_api.report_bot_version()
-        if event.extras.get("meshcore") and hasattr(self.radio, "run_coroutine"):
-            from src.meshcore.channel_sync import sync_channels_to_api
-
-            for storage_api in self.storage_apis:
-                sync_channels_to_api(self.radio, storage_api)
+        if event.extras.get("meshcore") and hasattr(
+            self.radio, "schedule_channel_sync"
+        ):
+            self.radio.schedule_channel_sync(self.storage_apis)
         self.print_nodes()
         if self.ws_client:
             self.ws_client.start()
@@ -142,6 +142,7 @@ class MeshflowBot:
             logger.warning("Radio disconnected: %s", error)
 
     def _on_packet(self, event: IncomingPacket) -> None:
+        log_incoming_packet(event)
         if event.raw is not None:
             if isinstance(event.raw, dict) and event.raw.get("meshcore"):
                 pass  # MeshCore JSON dumps live under data/meshcore_packets/ (see MeshCoreRadio)

--- a/src/bot.py
+++ b/src/bot.py
@@ -23,8 +23,12 @@ from src.persistence.node_info import AbstractNodeInfoStore
 from src.persistence.packet_dump import dump_packet
 from src.persistence.user_prefs import AbstractUserPrefsPersistence
 from src.radio.errors import call_safely, get_global_error_counter
-from src.radio.events import (ConnectionEstablished, IncomingPacket,
-                              IncomingTextMessage, NodeUpdate)
+from src.radio.events import (
+    ConnectionEstablished,
+    IncomingPacket,
+    IncomingTextMessage,
+    NodeUpdate,
+)
 from src.radio.interface import RadioHandlers, RadioInterface
 from src.responders.responder_factory import ResponderFactory
 
@@ -90,6 +94,23 @@ class MeshflowBot:
     def disconnect(self) -> None:
         self.radio.disconnect()
 
+    def on_apply_mc_channel_config(self, channels: list) -> None:
+        """Handle apply_mc_channel_config from WebSocket (MeshCore feeders)."""
+        from src.meshcore.channel_sync import (
+            apply_channels_on_device,
+            sync_channels_to_api,
+        )
+
+        if not hasattr(self.radio, "run_coroutine"):
+            logger.warning(
+                "apply_mc_channel_config ignored: radio does not support MeshCore channel IO"
+            )
+            return
+        if not apply_channels_on_device(self.radio, channels):
+            return
+        for storage_api in self.storage_apis:
+            sync_channels_to_api(self.radio, storage_api)
+
     def on_traceroute_command(self, target_node_id: int) -> None:
         """Handle a traceroute command (e.g. delivered via WebSocket)."""
         if not self.radio.is_connected:
@@ -106,6 +127,11 @@ class MeshflowBot:
         )
         for storage_api in self.storage_apis:
             storage_api.report_bot_version()
+        if event.extras.get("meshcore") and hasattr(self.radio, "run_coroutine"):
+            from src.meshcore.channel_sync import sync_channels_to_api
+
+            for storage_api in self.storage_apis:
+                sync_channels_to_api(self.radio, storage_api)
         self.print_nodes()
         if self.ws_client:
             self.ws_client.start()

--- a/src/main.py
+++ b/src/main.py
@@ -28,6 +28,7 @@ logging.getLogger("stream_interface").setLevel(logging.WARNING)
 logging.getLogger("mesh_interface").setLevel(logging.WARNING)
 
 from src.api.packet_serializer import PacketSerializer
+
 # Now we can import the rest of our local files
 from src.api.StorageAPI import StorageAPIWrapper
 from src.bot import MeshflowBot
@@ -184,11 +185,14 @@ def main() -> None:
         )
     if STORAGE_API_ROOT and STORAGE_API_TOKEN:
         ws_token = STORAGE_API_TOKEN
-    if ws_url and ws_token and RADIO_PROTOCOL == "meshtastic":
+    if ws_url and ws_token and RADIO_PROTOCOL in ("meshtastic", "meshcore"):
         bot.ws_client = MeshflowWSClient(
             ws_url=ws_url,
             api_key=ws_token,
             on_traceroute=bot.on_traceroute_command,
+            on_apply_mc_channel_config=(
+                bot.on_apply_mc_channel_config if RADIO_PROTOCOL == "meshcore" else None
+            ),
         )
 
     try:

--- a/src/meshcore/channel_sync.py
+++ b/src/meshcore/channel_sync.py
@@ -1,0 +1,54 @@
+"""Upload device channel snapshot to meshflow-api."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Optional
+
+from src.meshcore.channels import read_device_channels, snapshot_sync_body
+
+if TYPE_CHECKING:
+    from src.api.StorageAPI import StorageAPIWrapper
+    from src.meshcore.radio import MeshCoreRadio
+
+logger = logging.getLogger(__name__)
+
+
+def sync_channels_to_api(radio: "MeshCoreRadio", storage: "StorageAPIWrapper") -> bool:
+    """Read channels from device and POST mc-channel-sync. Returns True on HTTP success."""
+    if not radio.is_connected:
+        logger.warning("MeshCore channel sync skipped: radio not connected")
+        return False
+
+    async def _read():
+        mc = radio._meshcore  # noqa: SLF001 — intentional coupling for sync
+        if mc is None:
+            return []
+        return await read_device_channels(mc)
+
+    try:
+        channels = radio.run_coroutine(_read())
+    except Exception as exc:
+        logger.exception("MeshCore read_device_channels failed: %s", exc)
+        return False
+
+    body = snapshot_sync_body(channels)
+    return storage.post_mc_channel_sync(body)
+
+
+def apply_channels_on_device(radio: "MeshCoreRadio", channels: list[dict]) -> bool:
+    """Apply WS command payload to device, then caller should re-sync API."""
+    from src.meshcore.channels import apply_device_channels
+
+    async def _apply():
+        mc = radio._meshcore  # noqa: SLF001
+        if mc is None:
+            raise RuntimeError("MeshCore not connected")
+        await apply_device_channels(mc, channels)
+
+    try:
+        radio.run_coroutine(_apply())
+        return True
+    except Exception as exc:
+        logger.exception("MeshCore apply_device_channels failed: %s", exc)
+        return False

--- a/src/meshcore/channel_sync.py
+++ b/src/meshcore/channel_sync.py
@@ -14,26 +14,41 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def sync_channels_to_api(radio: "MeshCoreRadio", storage: "StorageAPIWrapper") -> bool:
-    """Read channels from device and POST mc-channel-sync. Returns True on HTTP success."""
+async def sync_channels_to_api_async(
+    radio: "MeshCoreRadio", storage: "StorageAPIWrapper"
+) -> bool:
+    """Read channels on the MeshCore asyncio loop and POST mc-channel-sync."""
     if not radio.is_connected:
         logger.warning("MeshCore channel sync skipped: radio not connected")
         return False
 
-    async def _read():
-        mc = radio._meshcore  # noqa: SLF001 — intentional coupling for sync
-        if mc is None:
-            return []
-        return await read_device_channels(mc)
-
-    try:
-        channels = radio.run_coroutine(_read())
-    except Exception as exc:
-        logger.exception("MeshCore read_device_channels failed: %s", exc)
-        return False
+    mc = radio._meshcore  # noqa: SLF001 — intentional coupling for sync
+    if mc is None:
+        channels: list[dict] = []
+    else:
+        try:
+            channels = await read_device_channels(mc)
+        except Exception as exc:
+            logger.exception("MeshCore read_device_channels failed: %s", exc)
+            return False
 
     body = snapshot_sync_body(channels)
     return storage.post_mc_channel_sync(body)
+
+
+def sync_channels_to_api(radio: "MeshCoreRadio", storage: "StorageAPIWrapper") -> bool:
+    """Sync from a non-radio thread (e.g. WebSocket worker). Do not call from the radio loop."""
+    if not hasattr(radio, "run_coroutine"):
+        logger.warning("MeshCore channel sync skipped: radio has no run_coroutine")
+        return False
+    try:
+        return radio.run_coroutine(
+            sync_channels_to_api_async(radio, storage),
+            timeout=120.0,
+        )
+    except Exception as exc:
+        logger.exception("MeshCore channel sync failed: %s", exc)
+        return False
 
 
 def apply_channels_on_device(radio: "MeshCoreRadio", channels: list[dict]) -> bool:

--- a/src/meshcore/channels.py
+++ b/src/meshcore/channels.py
@@ -1,0 +1,74 @@
+"""Read and write MeshCore companion channel table via meshcore_py."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from meshcore import MeshCore
+from meshcore.events import EventType
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_CHANNEL_SCAN = 16
+
+
+def _channel_entry_from_info(idx: int, payload: dict) -> Optional[dict]:
+    name = str(payload.get("channel_name", "") or "").strip()
+    if not name:
+        return None
+    if name.startswith("#"):
+        return {
+            "mc_channel_idx": idx,
+            "name": name.lstrip("#")[:100] or f"channel {idx}",
+            "mc_channel_type": "HASHTAG",
+            "mc_hashtag": name.lstrip("#")[:64],
+        }
+    return {
+        "mc_channel_idx": idx,
+        "name": name[:100],
+        "mc_channel_type": "PUBLIC",
+        "mc_hashtag": None,
+    }
+
+
+async def read_device_channels(
+    meshcore: MeshCore,
+    *,
+    max_channels: int = DEFAULT_MAX_CHANNEL_SCAN,
+) -> list[dict]:
+    """Return channel snapshot rows for API mc-channel-sync."""
+    channels: list[dict] = []
+    for idx in range(max_channels):
+        evt = await meshcore.commands.get_channel(idx)
+        if evt.type == EventType.ERROR:
+            continue
+        if evt.type != EventType.CHANNEL_INFO:
+            continue
+        payload = evt.payload if isinstance(evt.payload, dict) else {}
+        entry = _channel_entry_from_info(idx, payload)
+        if entry:
+            channels.append(entry)
+    return channels
+
+
+async def apply_device_channels(meshcore: MeshCore, channels: list[dict]) -> None:
+    """Write channel list to device (UI push path)."""
+    for ch in channels:
+        idx = int(ch["mc_channel_idx"])
+        name = str(ch.get("name") or f"channel {idx}")
+        ch_type = str(ch.get("mc_channel_type", "PUBLIC")).upper()
+        if ch_type == "HASHTAG":
+            tag = str(ch.get("mc_hashtag") or name).lstrip("#")
+            name = f"#{tag}"
+        evt = await meshcore.commands.set_channel(idx, name)
+        if evt.type == EventType.ERROR:
+            logger.warning("set_channel(%s) failed: %s", idx, evt.payload)
+
+
+def snapshot_sync_body(channels: list[dict]) -> dict:
+    return {
+        "channels": channels,
+        "synced_at": datetime.now(timezone.utc).isoformat(),
+    }

--- a/src/meshcore/radio.py
+++ b/src/meshcore/radio.py
@@ -257,6 +257,25 @@ class MeshCoreRadio(RadioInterface):
         """Synchronous hook for unit tests (same path as async subscriber)."""
         self._dispatch_meshcore_event(event)
 
+    def schedule_channel_sync(self, storage_apis: list) -> None:
+        """Schedule channel sync on the radio loop (must run on that loop's thread)."""
+        if not storage_apis:
+            return
+        loop = self._loop
+        if loop is None or not loop.is_running():
+            logger.warning(
+                "MeshCore channel sync not scheduled: event loop not running"
+            )
+            return
+
+        async def _task() -> None:
+            from src.meshcore.channel_sync import sync_channels_to_api_async
+
+            for storage in storage_apis:
+                await sync_channels_to_api_async(self, storage)
+
+        asyncio.create_task(_task())
+
     def run_coroutine(self, coro, *, timeout: float = 30.0):
         """Run a coroutine on the MeshCore asyncio loop from another thread."""
         import asyncio
@@ -264,6 +283,15 @@ class MeshCoreRadio(RadioInterface):
         loop = self._loop
         if loop is None or not loop.is_running():
             raise RadioError("MeshCoreRadio: event loop not running")
+        try:
+            running = asyncio.get_running_loop()
+        except RuntimeError:
+            running = None
+        if running is loop:
+            raise RadioError(
+                "MeshCoreRadio.run_coroutine called from the radio event loop; "
+                "use schedule_channel_sync or await the async helper instead"
+            )
         fut = asyncio.run_coroutine_threadsafe(coro, loop)
         return fut.result(timeout=timeout)
 

--- a/src/meshcore/radio.py
+++ b/src/meshcore/radio.py
@@ -118,8 +118,8 @@ class MeshCoreRadio(RadioInterface):
 
     @property
     def local_nodenum(self) -> Optional[int]:
-        """MeshCore nodes are pubkey-keyed; no Meshtastic-style nodenum."""
-        return None
+        """Feeder nodenum for API paths that still use ``/api/packets/{id}/…`` (MC uses 0)."""
+        return 0
 
     def send_text(
         self,

--- a/src/meshcore/radio.py
+++ b/src/meshcore/radio.py
@@ -81,12 +81,16 @@ class MeshCoreRadio(RadioInterface):
         self._shutdown.clear()
         self._started.clear()
         self._startup_error = None
-        self._thread = threading.Thread(target=self._thread_main, name="meshcore-radio", daemon=True)
+        self._thread = threading.Thread(
+            target=self._thread_main, name="meshcore-radio", daemon=True
+        )
         self._thread.start()
         if not self._started.wait(timeout=60.0):
             raise RadioError("MeshCoreRadio: timed out waiting for background connect")
         if self._startup_error is not None:
-            raise RadioError(f"MeshCoreRadio: connect failed: {self._startup_error!r}") from self._startup_error
+            raise RadioError(
+                f"MeshCoreRadio: connect failed: {self._startup_error!r}"
+            ) from self._startup_error
 
     def disconnect(self) -> None:
         self._shutdown.set()
@@ -160,7 +164,9 @@ class MeshCoreRadio(RadioInterface):
                 for t in pending:
                     t.cancel()
                 if pending:
-                    loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+                    loop.run_until_complete(
+                        asyncio.gather(*pending, return_exceptions=True)
+                    )
             except Exception:
                 logger.exception("MeshCoreRadio: error cancelling pending tasks")
             loop.close()
@@ -250,6 +256,16 @@ class MeshCoreRadio(RadioInterface):
     def dispatch_meshcore_event_for_tests(self, event: Event) -> None:
         """Synchronous hook for unit tests (same path as async subscriber)."""
         self._dispatch_meshcore_event(event)
+
+    def run_coroutine(self, coro, *, timeout: float = 30.0):
+        """Run a coroutine on the MeshCore asyncio loop from another thread."""
+        import asyncio
+
+        loop = self._loop
+        if loop is None or not loop.is_running():
+            raise RadioError("MeshCoreRadio: event loop not running")
+        fut = asyncio.run_coroutine_threadsafe(coro, loop)
+        return fut.result(timeout=timeout)
 
     def _dispatch_meshcore_event(self, event: Event) -> None:
         et = event.type

--- a/src/meshcore/serializers.py
+++ b/src/meshcore/serializers.py
@@ -14,6 +14,17 @@ logger = logging.getLogger(__name__)
 UPLOADABLE_PAYLOAD_TYPES = frozenset({"advert", "channel_text", "contact_text"})
 
 
+def _json_safe(value: Any) -> Any:
+    """Recursively coerce meshcore event payloads to JSON-serialisable values."""
+    if isinstance(value, bytes):
+        return value.hex()
+    if isinstance(value, dict):
+        return {k: _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(v) for v in value]
+    return value
+
+
 class MeshCoreSkipUpload(Exception):
     """Raised when a frame should not be uploaded (capture-only path)."""
 
@@ -76,7 +87,7 @@ def _build_from_envelope(envelope: dict[str, Any]) -> dict[str, Any]:
         "route_typename": payload.get("route_typename"),
         "path_hashes": _path_hashes(payload),
         "pkt_hash": payload.get("pkt_hash"),
-        "raw": envelope,
+        "raw": _json_safe(envelope),
     }
 
     if event_type == "advertisement":

--- a/src/packet_log.py
+++ b/src/packet_log.py
@@ -1,0 +1,96 @@
+"""Optional console logging of abridged packet summaries (``LOG_PACKETS=true``)."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Optional
+
+from src.radio.events import IncomingPacket
+
+logger = logging.getLogger(__name__)
+
+
+def log_packets_enabled() -> bool:
+    return os.getenv("LOG_PACKETS", "false").lower() in ("1", "true", "yes")
+
+
+def _truncate(value: Any, *, max_len: int = 80) -> str:
+    text = str(value).replace("\n", " ")
+    if len(text) <= max_len:
+        return text
+    return f"{text[: max_len - 3]}..."
+
+
+def log_incoming_packet(event: IncomingPacket) -> None:
+    """Log a one-line summary of an MC or MT packet when ``LOG_PACKETS`` is enabled."""
+    if not log_packets_enabled():
+        return
+
+    raw = event.raw if isinstance(event.raw, dict) else {}
+    if raw.get("meshcore") or raw.get("protocol") == "meshcore":
+        evt = raw.get("type") or raw.get("event_type") or event.portnum
+        payload = raw.get("payload") if isinstance(raw.get("payload"), dict) else {}
+        detail = _mc_payload_detail(payload)
+        logger.info(
+            "MC %s from=%s ch=%s%s",
+            evt,
+            event.from_id or "-",
+            event.channel,
+            detail,
+        )
+        return
+
+    if isinstance(raw, dict) and "decoded" in raw:
+        decoded = raw.get("decoded") if isinstance(raw.get("decoded"), dict) else {}
+        portnum = decoded.get("portnum") or event.portnum
+        logger.info(
+            "MT %s from=%s to=%s ch=%s id=%s%s",
+            portnum,
+            event.from_id or "-",
+            event.to_id or "-",
+            event.channel,
+            raw.get("id", "-"),
+            _mt_decoded_detail(decoded),
+        )
+        return
+
+    logger.info(
+        "pkt %s from=%s to=%s ch=%s decoded=%s",
+        event.portnum,
+        event.from_id or "-",
+        event.to_id or "-",
+        event.channel,
+        event.has_decoded,
+    )
+
+
+def _mc_payload_detail(payload: dict) -> str:
+    if not payload:
+        return ""
+    if "text" in payload:
+        return f' text="{_truncate(payload.get("text"), max_len=60)}"'
+    if payload.get("payload_typename"):
+        return f" typename={payload['payload_typename']}"
+    if payload.get("public_key"):
+        pk = str(payload["public_key"])
+        return f" pubkey={pk[:12]}…"
+    if payload.get("pubkey_prefix"):
+        return f" prefix={payload['pubkey_prefix']}"
+    if payload.get("channel_name"):
+        return f' name="{_truncate(payload["channel_name"], max_len=40)}"'
+    return ""
+
+
+def _mt_decoded_detail(decoded: dict) -> str:
+    if not decoded:
+        return ""
+    if decoded.get("portnum") == "TEXT_MESSAGE_APP":
+        text = decoded.get("text") or (decoded.get("payload") or {}).get("text")
+        if text:
+            return f' text="{_truncate(text, max_len=60)}"'
+    if decoded.get("portnum") == "POSITION_APP":
+        pos = decoded.get("position") or (decoded.get("payload") or {}).get("position")
+        if isinstance(pos, dict) and "latitudeI" in pos:
+            return " pos=…"
+    return ""

--- a/src/ws_client.py
+++ b/src/ws_client.py
@@ -26,6 +26,7 @@ class MeshflowWSClient:
         ws_url: str,
         api_key: str,
         on_traceroute: Callable[[int], None],
+        on_apply_mc_channel_config: Optional[Callable[[list], None]] = None,
         on_connect: Optional[Callable[[], None]] = None,
         on_disconnect: Optional[Callable[[], None]] = None,
     ):
@@ -40,6 +41,7 @@ class MeshflowWSClient:
         self.ws_url = ws_url.rstrip("/")
         self.api_key = api_key
         self.on_traceroute = on_traceroute
+        self.on_apply_mc_channel_config = on_apply_mc_channel_config
         self.on_connect = on_connect
         self.on_disconnect = on_disconnect
 
@@ -102,7 +104,9 @@ class MeshflowWSClient:
                 break
 
             await asyncio.sleep(backoff)
-            backoff = getattr(self, "_backoff", backoff)  # Use reset value from successful connect
+            backoff = getattr(
+                self, "_backoff", backoff
+            )  # Use reset value from successful connect
             backoff = min(backoff * 1.5, max_backoff)
 
         logger.info("MeshflowWSClient: run loop ended")
@@ -113,7 +117,9 @@ class MeshflowWSClient:
             import websockets
             from websockets.exceptions import ConnectionClosed
         except ImportError:
-            raise ImportError("websockets package required. Install with: pip install websockets")
+            raise ImportError(
+                "websockets package required. Install with: pip install websockets"
+            )
 
         endpoint = self._get_ws_endpoint()
         # Django Channels AllowedHostsOriginValidator requires Origin header.
@@ -141,7 +147,9 @@ class MeshflowWSClient:
                     continue
                 except ConnectionClosed as e:
                     code = getattr(getattr(e, "rcvd", None), "code", None)
-                    logger.info(f"MeshflowWSClient: connection closed by server (code={code})")
+                    logger.info(
+                        f"MeshflowWSClient: connection closed by server (code={code})"
+                    )
                     raise
 
                 try:
@@ -156,22 +164,58 @@ class MeshflowWSClient:
                     if target is not None:
                         try:
                             target_id = int(target)
-                            logger.info(f"MeshflowWSClient: received traceroute command, target={target_id}")
+                            logger.info(
+                                f"MeshflowWSClient: received traceroute command, target={target_id}"
+                            )
                             # Run in thread so a blocking/long-running TR doesn't block receiving
                             # further commands (e.g. multiple TRs in quick succession, or TR that never returns)
-                            task = asyncio.create_task(asyncio.to_thread(self.on_traceroute, target_id))
+                            task = asyncio.create_task(
+                                asyncio.to_thread(self.on_traceroute, target_id)
+                            )
 
                             def _task_done(t):
                                 if t.cancelled():
                                     return
                                 exc = t.exception()
                                 if exc:
-                                    logger.warning(f"MeshflowWSClient: traceroute task failed: {exc}")
+                                    logger.warning(
+                                        f"MeshflowWSClient: traceroute task failed: {exc}"
+                                    )
 
                             task.add_done_callback(_task_done)
                         except (TypeError, ValueError):
-                            logger.warning(f"MeshflowWSClient: invalid traceroute target: {target}")
+                            logger.warning(
+                                f"MeshflowWSClient: invalid traceroute target: {target}"
+                            )
                     else:
-                        logger.warning("MeshflowWSClient: traceroute command missing target")
+                        logger.warning(
+                            "MeshflowWSClient: traceroute command missing target"
+                        )
+                elif cmd_type == "apply_mc_channel_config":
+                    channels = data.get("channels")
+                    if channels is not None and self.on_apply_mc_channel_config:
+                        logger.info(
+                            "MeshflowWSClient: received apply_mc_channel_config (%s channels)",
+                            len(channels),
+                        )
+                        task = asyncio.create_task(
+                            asyncio.to_thread(self.on_apply_mc_channel_config, channels)
+                        )
+
+                        def _apply_done(t):
+                            if t.cancelled():
+                                return
+                            exc = t.exception()
+                            if exc:
+                                logger.warning(
+                                    "MeshflowWSClient: apply_mc_channel_config failed: %s",
+                                    exc,
+                                )
+
+                        task.add_done_callback(_apply_done)
+                    else:
+                        logger.warning(
+                            "MeshflowWSClient: apply_mc_channel_config missing channels or handler"
+                        )
                 else:
                     logger.debug(f"MeshflowWSClient: ignored command type: {cmd_type}")

--- a/test/meshcore/test_channel_sync.py
+++ b/test/meshcore/test_channel_sync.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from src.meshcore.channel_sync import apply_channels_on_device, sync_channels_to_api
+from src.meshcore.channel_sync import (
+    apply_channels_on_device,
+    sync_channels_to_api,
+    sync_channels_to_api_async,
+)
 
 
 class _MeshCoreRadioStub:
@@ -26,6 +30,24 @@ class _MeshCoreRadioStub:
         if asyncio.iscoroutine(coro):
             return asyncio.run(coro)
         return None
+
+
+def test_sync_channels_to_api_async_posts_snapshot() -> None:
+    radio = _MeshCoreRadioStub(connected=True, meshcore=MagicMock())
+    storage = MagicMock()
+    storage.post_mc_channel_sync.return_value = True
+    channels = [{"mc_channel_idx": 0, "name": "Public", "mc_channel_type": "PUBLIC"}]
+
+    async def _run():
+        with patch(
+            "src.meshcore.channel_sync.read_device_channels",
+            new_callable=AsyncMock,
+            return_value=channels,
+        ):
+            return await sync_channels_to_api_async(radio, storage)
+
+    assert asyncio.run(_run()) is True
+    storage.post_mc_channel_sync.assert_called_once()
 
 
 def test_sync_channels_skipped_when_disconnected() -> None:

--- a/test/meshcore/test_channel_sync.py
+++ b/test/meshcore/test_channel_sync.py
@@ -1,0 +1,98 @@
+"""Tests for :mod:`src.meshcore.channel_sync`."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.meshcore.channel_sync import apply_channels_on_device, sync_channels_to_api
+
+
+class _MeshCoreRadioStub:
+    def __init__(
+        self,
+        *,
+        connected: bool = True,
+        meshcore=None,
+        run_raises: Exception | None = None,
+    ):
+        self.is_connected = connected
+        self._meshcore = meshcore
+        self._run_raises = run_raises
+
+    def run_coroutine(self, coro, *, timeout: float = 30.0):
+        if self._run_raises is not None:
+            raise self._run_raises
+        if asyncio.iscoroutine(coro):
+            return asyncio.run(coro)
+        return None
+
+
+def test_sync_channels_skipped_when_disconnected() -> None:
+    radio = _MeshCoreRadioStub(connected=False)
+    storage = MagicMock()
+    assert sync_channels_to_api(radio, storage) is False
+    storage.post_mc_channel_sync.assert_not_called()
+
+
+def test_sync_channels_posts_snapshot() -> None:
+    radio = _MeshCoreRadioStub(connected=True, meshcore=MagicMock())
+    storage = MagicMock()
+    storage.post_mc_channel_sync.return_value = True
+    channels = [{"mc_channel_idx": 0, "name": "Public", "mc_channel_type": "PUBLIC"}]
+    with patch(
+        "src.meshcore.channel_sync.read_device_channels",
+        new_callable=AsyncMock,
+        return_value=channels,
+    ):
+        assert sync_channels_to_api(radio, storage) is True
+    storage.post_mc_channel_sync.assert_called_once()
+    body = storage.post_mc_channel_sync.call_args[0][0]
+    assert body["channels"][0]["name"] == "Public"
+    assert "synced_at" in body
+
+
+def test_sync_channels_returns_false_when_read_fails() -> None:
+    radio = _MeshCoreRadioStub(connected=True, run_raises=RuntimeError("loop down"))
+    storage = MagicMock()
+    assert sync_channels_to_api(radio, storage) is False
+    storage.post_mc_channel_sync.assert_not_called()
+
+
+def test_sync_channels_empty_when_meshcore_none() -> None:
+    radio = _MeshCoreRadioStub(connected=True, meshcore=None)
+    storage = MagicMock()
+    storage.post_mc_channel_sync.return_value = True
+    assert sync_channels_to_api(radio, storage) is True
+    assert storage.post_mc_channel_sync.call_args[0][0]["channels"] == []
+
+
+def test_apply_channels_success() -> None:
+    radio = _MeshCoreRadioStub(connected=True, meshcore=MagicMock())
+    channels = [
+        {
+            "mc_channel_idx": 1,
+            "name": "galloway",
+            "mc_channel_type": "HASHTAG",
+            "mc_hashtag": "galloway",
+        }
+    ]
+    with patch(
+        "src.meshcore.channels.apply_device_channels", new_callable=AsyncMock
+    ) as apply_mock:
+        assert apply_channels_on_device(radio, channels) is True
+        apply_mock.assert_awaited_once()
+
+
+def test_apply_channels_fails_when_not_connected() -> None:
+    radio = _MeshCoreRadioStub(connected=True, meshcore=None)
+    assert (
+        apply_channels_on_device(radio, [{"mc_channel_idx": 0, "name": "x"}]) is False
+    )
+
+
+def test_apply_channels_returns_false_on_exception() -> None:
+    radio = _MeshCoreRadioStub(connected=True, run_raises=OSError("serial gone"))
+    assert (
+        apply_channels_on_device(radio, [{"mc_channel_idx": 0, "name": "x"}]) is False
+    )

--- a/test/meshcore/test_channels.py
+++ b/test/meshcore/test_channels.py
@@ -1,6 +1,18 @@
 """Unit tests for MeshCore channel snapshot helpers."""
 
-from src.meshcore.channels import _channel_entry_from_info, snapshot_sync_body
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from meshcore.events import Event, EventType
+
+from src.meshcore.channels import (
+    _channel_entry_from_info,
+    apply_device_channels,
+    read_device_channels,
+    snapshot_sync_body,
+)
 
 
 def test_channel_entry_public():
@@ -21,3 +33,49 @@ def test_snapshot_sync_body():
     )
     assert "synced_at" in body
     assert len(body["channels"]) == 1
+
+
+def test_channel_entry_empty_name_returns_none() -> None:
+    assert _channel_entry_from_info(0, {"channel_name": "   "}) is None
+
+
+def test_read_device_channels_collects_public_and_skips_errors() -> None:
+    mc = MagicMock()
+    mc.commands.get_channel = AsyncMock(
+        side_effect=[
+            Event(EventType.ERROR, {}, {}),
+            Event(EventType.CHANNEL_INFO, {"channel_name": "Public"}, {}),
+            Event(EventType.CHANNEL_INFO, {"channel_name": ""}, {}),
+            Event(EventType.ERROR, {}, {}),
+        ]
+    )
+    channels = asyncio.run(read_device_channels(mc, max_channels=4))
+    assert len(channels) == 1
+    assert channels[0]["mc_channel_type"] == "PUBLIC"
+
+
+def test_apply_device_channels_hashtag_and_error() -> None:
+    mc = MagicMock()
+    mc.commands.set_channel = AsyncMock(
+        side_effect=[
+            Event(EventType.CHANNEL_INFO, {}, {}),
+            Event(EventType.ERROR, {"msg": "fail"}, {}),
+        ]
+    )
+    asyncio.run(
+        apply_device_channels(
+            mc,
+            [
+                {
+                    "mc_channel_idx": 1,
+                    "name": "galloway",
+                    "mc_channel_type": "HASHTAG",
+                    "mc_hashtag": "galloway",
+                },
+                {"mc_channel_idx": 2, "name": "two", "mc_channel_type": "PUBLIC"},
+            ],
+        )
+    )
+    assert mc.commands.set_channel.await_count == 2
+    first_call = mc.commands.set_channel.await_args_list[0]
+    assert first_call[0] == (1, "#galloway")

--- a/test/meshcore/test_channels.py
+++ b/test/meshcore/test_channels.py
@@ -1,0 +1,23 @@
+"""Unit tests for MeshCore channel snapshot helpers."""
+
+from src.meshcore.channels import _channel_entry_from_info, snapshot_sync_body
+
+
+def test_channel_entry_public():
+    entry = _channel_entry_from_info(0, {"channel_name": "Public"})
+    assert entry["mc_channel_type"] == "PUBLIC"
+    assert entry["mc_hashtag"] is None
+
+
+def test_channel_entry_hashtag():
+    entry = _channel_entry_from_info(1, {"channel_name": "#galloway"})
+    assert entry["mc_channel_type"] == "HASHTAG"
+    assert entry["mc_hashtag"] == "galloway"
+
+
+def test_snapshot_sync_body():
+    body = snapshot_sync_body(
+        [{"mc_channel_idx": 0, "name": "X", "mc_channel_type": "PUBLIC"}]
+    )
+    assert "synced_at" in body
+    assert len(body["channels"]) == 1

--- a/test/meshcore/test_radio_channel_sync.py
+++ b/test/meshcore/test_radio_channel_sync.py
@@ -1,0 +1,51 @@
+"""Regression: channel sync must not block the MeshCore asyncio loop."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.meshcore.radio import MeshCoreRadio
+from src.radio.errors import RadioError
+
+
+def test_run_coroutine_rejects_call_from_radio_loop() -> None:
+    async def _runner():
+        radio = MeshCoreRadio.__new__(MeshCoreRadio)
+        loop = asyncio.get_running_loop()
+        radio._loop = loop  # noqa: SLF001
+
+        async def _noop():
+            return None
+
+        with pytest.raises(RadioError, match="radio event loop"):
+            radio.run_coroutine(_noop())
+
+    asyncio.run(_runner())
+
+
+def test_schedule_channel_sync_runs_on_loop() -> None:
+    async def _runner():
+        radio = MeshCoreRadio.__new__(MeshCoreRadio)
+        loop = asyncio.get_running_loop()
+        radio._loop = loop  # noqa: SLF001
+        radio._meshcore = MagicMock()
+        radio._meshcore.is_connected = True
+
+        storage = MagicMock()
+        done = asyncio.Event()
+
+        async def _fake_sync(_radio, _storage):
+            done.set()
+            return True
+
+        with patch(
+            "src.meshcore.channel_sync.sync_channels_to_api_async",
+            side_effect=_fake_sync,
+        ):
+            radio.schedule_channel_sync([storage])
+            await asyncio.wait_for(done.wait(), timeout=1.0)
+
+    asyncio.run(_runner())

--- a/test/meshcore/test_serializers.py
+++ b/test/meshcore/test_serializers.py
@@ -8,8 +8,7 @@ from pathlib import Path
 import pytest
 
 from src.data_classes import MeshNode
-from src.meshcore.serializers import (MeshCorePacketSerializer,
-                                      MeshCoreSkipUpload)
+from src.meshcore.serializers import MeshCorePacketSerializer, MeshCoreSkipUpload
 
 DOCS = Path(__file__).resolve().parents[2] / "docs" / "meshcore_packets"
 
@@ -83,6 +82,21 @@ def test_skip_rx_log_text() -> None:
     }
     with pytest.raises(MeshCoreSkipUpload):
         MeshCorePacketSerializer().serialise_raw_packet(raw)
+
+
+def test_rx_log_data_serialises_bytes_in_raw_payload() -> None:
+    dump = _load("rx_log_data/20260506_211139_847711.json")
+    payload = dict(dump["payload"])
+    payload["pkt_payload"] = b"\x00\xd5h\x00\x00\x82p"
+    raw = {
+        "meshcore": True,
+        "type": "rx_log_data",
+        "payload": payload,
+        "attributes": {},
+    }
+    out = MeshCorePacketSerializer().serialise_raw_packet(raw)
+    assert isinstance(out["raw"]["payload"]["pkt_payload"], str)
+    assert out["raw"]["payload"]["pkt_payload"] == payload["pkt_payload"].hex()
 
 
 def test_node_methods_not_implemented() -> None:

--- a/test/meshcore/test_storage_upload.py
+++ b/test/meshcore/test_storage_upload.py
@@ -31,3 +31,40 @@ def test_store_raw_meshcore_packet_posts_to_ingest() -> None:
     args, kwargs = post.call_args
     assert args[0] == "/api/meshcore/packets/ingest/"
     assert kwargs["json"]["payload_type"] == "advert"
+
+
+def test_post_mc_channel_sync_success() -> None:
+    wrapper = StorageAPIWrapper(
+        "http://api.test",
+        token="secret",
+        api_version=2,
+        serializer=MeshCorePacketSerializer(),
+        local_meshtastic_nodenum_provider=lambda: None,
+    )
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    with patch.object(wrapper, "_post", return_value=mock_response) as post:
+        ok = wrapper.post_mc_channel_sync(
+            {"channels": [], "synced_at": "2026-01-01T00:00:00Z"}
+        )
+    assert ok is True
+    post.assert_called_once_with(
+        "/api/meshcore/feeder/mc-channel-sync/",
+        json={"channels": [], "synced_at": "2026-01-01T00:00:00Z"},
+    )
+
+
+def test_post_mc_channel_sync_http_error_returns_false() -> None:
+    from requests import HTTPError
+
+    wrapper = StorageAPIWrapper(
+        "http://api.test",
+        token="secret",
+        api_version=2,
+        serializer=MeshCorePacketSerializer(),
+        local_meshtastic_nodenum_provider=lambda: None,
+    )
+    response = MagicMock()
+    response.text = "bad"
+    with patch.object(wrapper, "_post", side_effect=HTTPError(response=response)):
+        assert wrapper.post_mc_channel_sync({"channels": []}) is False

--- a/test/meshcore/test_translation.py
+++ b/test/meshcore/test_translation.py
@@ -6,7 +6,13 @@ import json
 from pathlib import Path
 
 from meshcore.events import Event, EventType
-from src.meshcore.translation import event_to_incoming_packet
+from src.meshcore.translation import (
+    event_to_incoming_packet,
+    event_to_node_update,
+    event_to_text_message,
+    mc_id_from_full_pubkey,
+    mc_id_from_prefix,
+)
 
 DOCS = Path(__file__).resolve().parents[2] / "docs" / "meshcore_packets"
 
@@ -36,3 +42,84 @@ def test_rx_log_data_fixture_serialises_with_coords() -> None:
     assert out["event_type"] == "rx_log_data"
     assert out["payload_type"] == "advert"
     assert out["adv_lat"] == 55.99578
+
+
+def test_mc_id_helpers() -> None:
+    pk = "A" * 64
+    assert mc_id_from_full_pubkey(pk) == f"mc:{pk.lower()}"
+    assert mc_id_from_prefix("AABBCCDDEEFF") == "mc:p:aabbccddeeff"
+
+
+def test_advertisement_incoming_packet() -> None:
+    dump = _load("advertisement/20260506_220053_180858.json")
+    event = Event(EventType.ADVERTISEMENT, dump["payload"])
+    packet = event_to_incoming_packet(event)
+    assert packet is not None
+    assert packet.from_id.startswith("mc:")
+
+
+def test_path_update_incoming_packet() -> None:
+    dump = _load("path_update/20260506_205759_895381.json")
+    event = Event(EventType.PATH_UPDATE, dump["payload"])
+    packet = event_to_incoming_packet(event)
+    assert packet is not None
+    assert packet.portnum == "MC_PATH_UPDATE"
+
+
+def test_messages_waiting_incoming_packet() -> None:
+    dump = _load("messages_waiting/20260506_205758_540343.json")
+    event = Event(EventType.MESSAGES_WAITING, dump["payload"])
+    packet = event_to_incoming_packet(event)
+    assert packet is not None
+    assert packet.portnum == "MC_MESSAGES_WAITING"
+
+
+def test_contact_message_text_dm() -> None:
+    dump = _load("contact_messages/20260506_205758_541689.json")
+    event = Event(EventType.CONTACT_MSG_RECV, dump["payload"])
+    msg = event_to_text_message(event, local_node_id="mc:local")
+    assert msg is not None
+    assert msg.is_dm is True
+    assert msg.from_id.startswith("mc:p:")
+
+
+def test_channel_message_text_broadcast() -> None:
+    dump = _load("channel_messages/20260507_094921_075978.json")
+    event = Event(EventType.CHANNEL_MSG_RECV, dump["payload"])
+    msg = event_to_text_message(event, local_node_id="mc:local")
+    assert msg is not None
+    assert msg.is_dm is False
+    assert msg.to_id.startswith("mc:channel:")
+
+
+def test_contact_message_missing_prefix_returns_none() -> None:
+    event = Event(EventType.CONTACT_MSG_RECV, {"type": "PRIV", "text": "hi"})
+    assert event_to_text_message(event, local_node_id="mc:local") is None
+
+
+def test_advertisement_node_update() -> None:
+    dump = _load("advertisement/20260506_220053_180858.json")
+    event = Event(EventType.ADVERTISEMENT, dump["payload"])
+    update = event_to_node_update(event)
+    assert update is not None
+    assert update.node.user.hw_model == "MESHCORE"
+
+
+def test_self_info_incoming_packet() -> None:
+    event = Event(
+        EventType.SELF_INFO,
+        {"public_key": "ab" * 32},
+    )
+    packet = event_to_incoming_packet(event)
+    assert packet is not None
+    assert packet.is_self_telemetry is True
+    assert packet.from_id == mc_id_from_full_pubkey("ab" * 32)
+
+
+def test_battery_and_ack_packets() -> None:
+    batt = event_to_incoming_packet(Event(EventType.BATTERY, {"level": 50}))
+    assert batt is not None
+    assert batt.is_self_telemetry is True
+    ack = event_to_incoming_packet(Event(EventType.ACK, {}))
+    assert ack is not None
+    assert ack.portnum == "MC_ACK"

--- a/test/persistence/test_packet_dump.py
+++ b/test/persistence/test_packet_dump.py
@@ -1,0 +1,40 @@
+"""Tests for :mod:`src.persistence.packet_dump`."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import src.persistence.packet_dump as packet_dump
+
+
+def test_dump_packet_noop_when_portnums_unset(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(packet_dump, "dump_portnums", None)
+    packet_dump.dump_packet({"decoded": {"portnum": "TEXT_MESSAGE_APP"}})
+    assert not (tmp_path / "data").exists()
+
+
+def test_dump_packet_writes_json(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(packet_dump, "dump_portnums", ["TEXT_MESSAGE_APP"])
+    packet = {"decoded": {"portnum": "TEXT_MESSAGE_APP"}, "id": 1}
+    packet_dump.dump_packet(packet)
+    out_dir = tmp_path / "data" / "packets" / "TEXT_MESSAGE_APP"
+    files = list(out_dir.glob("*.json"))
+    assert len(files) == 1
+    assert json.loads(files[0].read_text())["id"] == 1
+
+
+def test_dump_packet_wildcard(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(packet_dump, "dump_portnums", ["*"])
+    packet_dump.dump_packet({"decoded": {"portnum": "NODEINFO_APP"}})
+    assert list((tmp_path / "data" / "packets" / "NODEINFO_APP").glob("*.json"))
+
+
+def test_dump_packet_skips_unlisted_portnum(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(packet_dump, "dump_portnums", ["TEXT_MESSAGE_APP"])
+    packet_dump.dump_packet({"decoded": {"portnum": "POSITION_APP"}})
+    assert not (tmp_path / "data" / "packets" / "POSITION_APP").exists()

--- a/test/responders/test_responder_factory.py
+++ b/test/responders/test_responder_factory.py
@@ -1,0 +1,18 @@
+"""Tests for :mod:`src.responders.responder_factory`."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from src.responders.message_reaction_responder import MessageReactionResponder
+from src.responders.responder_factory import ResponderFactory
+
+
+def test_match_responder_returns_instance() -> None:
+    bot = MagicMock()
+    responder = ResponderFactory.match_responder("test", bot)
+    assert isinstance(responder, MessageReactionResponder)
+
+
+def test_match_responder_returns_none_for_unknown() -> None:
+    assert ResponderFactory.match_responder("no match here", MagicMock()) is None

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -50,24 +50,21 @@ class TestMeshflowBot(unittest.TestCase):
         apply_mock.assert_called_once_with(mc_radio, channels)
         self.assertEqual(sync_mock.call_count, 2)
 
-    def test_meshcore_connection_triggers_channel_sync(self):
+    def test_meshcore_connection_schedules_channel_sync(self):
         mc_radio = MagicMock()
-        mc_radio.run_coroutine = MagicMock()
+        mc_radio.schedule_channel_sync = MagicMock()
         bot = MeshflowBot(radio=mc_radio)
         bot.storage_apis = [MagicMock()]
         bot.print_nodes = MagicMock()
         bot.ws_client = None
-        with patch(
-            "src.meshcore.channel_sync.sync_channels_to_api", return_value=True
-        ) as sync_mock:
-            bot._on_connection_established(
-                ConnectionEstablished(
-                    local_node_id="mc:abc",
-                    local_nodenum=0,
-                    extras={"meshcore": True},
-                )
+        bot._on_connection_established(
+            ConnectionEstablished(
+                local_node_id="mc:abc",
+                local_nodenum=0,
+                extras={"meshcore": True},
             )
-        sync_mock.assert_called_once()
+        )
+        mc_radio.schedule_channel_sync.assert_called_once_with(bot.storage_apis)
 
 
 if __name__ == "__main__":

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -1,12 +1,14 @@
 import unittest
+from unittest.mock import MagicMock, patch
 
 from src.bot import MeshflowBot
+from src.radio.events import ConnectionEstablished
 from test.fake_radio import FakeRadio
 
 
 class TestMeshflowBot(unittest.TestCase):
     def setUp(self):
-        self.fake_radio = FakeRadio(local_node_id="!aabbccdd", local_nodenum=0xaabbccdd)
+        self.fake_radio = FakeRadio(local_node_id="!aabbccdd", local_nodenum=0xAABBCCDD)
         self.bot = MeshflowBot(radio=self.fake_radio)
 
     def test_connect_delegates_to_radio(self):
@@ -19,7 +21,7 @@ class TestMeshflowBot(unittest.TestCase):
 
     def test_my_id_proxies_radio(self):
         self.assertEqual(self.bot.my_id, "!aabbccdd")
-        self.assertEqual(self.bot.my_nodenum, 0xaabbccdd)
+        self.assertEqual(self.bot.my_nodenum, 0xAABBCCDD)
 
     def test_traceroute_skipped_when_disconnected(self):
         self.bot.on_traceroute_command(0x12345678)
@@ -30,6 +32,43 @@ class TestMeshflowBot(unittest.TestCase):
         self.bot.on_traceroute_command(0x12345678)
         self.fake_radio.send_traceroute.assert_called_once_with(0x12345678)
 
+    def test_apply_mc_channel_config_ignored_without_run_coroutine(self):
+        self.bot.on_apply_mc_channel_config([{"mc_channel_idx": 0, "name": "x"}])
 
-if __name__ == '__main__':
+    def test_apply_mc_channel_config_syncs_after_apply(self):
+        mc_radio = MagicMock()
+        mc_radio.run_coroutine = MagicMock()
+        bot = MeshflowBot(radio=mc_radio)
+        bot.storage_apis = [MagicMock(), MagicMock()]
+        channels = [{"mc_channel_idx": 0, "name": "Public"}]
+        with patch(
+            "src.meshcore.channel_sync.apply_channels_on_device", return_value=True
+        ) as apply_mock, patch(
+            "src.meshcore.channel_sync.sync_channels_to_api", return_value=True
+        ) as sync_mock:
+            bot.on_apply_mc_channel_config(channels)
+        apply_mock.assert_called_once_with(mc_radio, channels)
+        self.assertEqual(sync_mock.call_count, 2)
+
+    def test_meshcore_connection_triggers_channel_sync(self):
+        mc_radio = MagicMock()
+        mc_radio.run_coroutine = MagicMock()
+        bot = MeshflowBot(radio=mc_radio)
+        bot.storage_apis = [MagicMock()]
+        bot.print_nodes = MagicMock()
+        bot.ws_client = None
+        with patch(
+            "src.meshcore.channel_sync.sync_channels_to_api", return_value=True
+        ) as sync_mock:
+            bot._on_connection_established(
+                ConnectionEstablished(
+                    local_node_id="mc:abc",
+                    local_nodenum=0,
+                    extras={"meshcore": True},
+                )
+            )
+        sync_mock.assert_called_once()
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/test/test_bot_version_report.py
+++ b/test/test_bot_version_report.py
@@ -35,6 +35,21 @@ def test_report_bot_version_puts_v2_path() -> None:
     assert put.call_args[1]["json"]["bot_version"] == get_bot_version()
 
 
+def test_report_bot_version_accepts_meshcore_feeder_nodenum_zero() -> None:
+    """MeshCore radios expose nodenum 0 for API feeder paths (not None)."""
+    wrapper = StorageAPIWrapper(
+        "http://api.test",
+        token="secret",
+        api_version=2,
+        serializer=MeshtasticPacketSerializer(),
+        local_meshtastic_nodenum_provider=lambda: 0,
+    )
+    mock_response = MagicMock()
+    with patch.object(wrapper, "_put", return_value=mock_response) as put:
+        assert wrapper.report_bot_version() is True
+    assert put.call_args[0][0] == "/api/packets/0/bot-version/"
+
+
 def test_report_bot_version_skipped_for_v1() -> None:
     wrapper = StorageAPIWrapper(
         "http://api.test",

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -1,7 +1,7 @@
 import unittest
 from datetime import datetime, timedelta, timezone
 
-from src.helpers import pretty_print_last_heard
+from src.helpers import pretty_print_last_heard, safe_encode_node_name
 
 
 class TestPrettyPrintLastHeard(unittest.TestCase):
@@ -55,6 +55,17 @@ class TestPrettyPrintLastHeard(unittest.TestCase):
         future_time = now + timedelta(seconds=10)
         self.assertEqual(pretty_print_last_heard(future_time), "0s ago")
 
+    def test_never_when_none(self):
+        self.assertEqual(pretty_print_last_heard(None), "never")
 
-if __name__ == '__main__':
+
+class TestSafeEncodeNodeName(unittest.TestCase):
+    def test_ascii_unchanged(self):
+        self.assertEqual(safe_encode_node_name("Node A"), "Node A")
+
+    def test_non_ascii_percent_encoded(self):
+        self.assertEqual(safe_encode_node_name("café"), "caf%C3%A9")
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/test/test_packet_log.py
+++ b/test/test_packet_log.py
@@ -1,0 +1,76 @@
+"""Tests for :mod:`src.packet_log`."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from src.packet_log import log_incoming_packet, log_packets_enabled
+from src.radio.events import IncomingPacket
+
+
+def test_log_packets_disabled_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("LOG_PACKETS", raising=False)
+    assert log_packets_enabled() is False
+
+
+def test_log_packets_enabled(monkeypatch) -> None:
+    monkeypatch.setenv("LOG_PACKETS", "true")
+    assert log_packets_enabled() is True
+
+
+@patch("src.packet_log.logger")
+def test_log_meshcore_packet(mock_logger, monkeypatch) -> None:
+    monkeypatch.setenv("LOG_PACKETS", "true")
+    log_incoming_packet(
+        IncomingPacket(
+            portnum="MC_CHANNEL_MSG_RECV",
+            from_id="mc:channel:0:rx",
+            to_id=None,
+            channel=0,
+            has_decoded=True,
+            raw={
+                "meshcore": True,
+                "type": "channel_message",
+                "payload": {"text": "hello mesh", "channel_idx": 0},
+                "attributes": {},
+            },
+        )
+    )
+    mock_logger.info.assert_called_once()
+    args = mock_logger.info.call_args[0]
+    assert "channel_message" in " ".join(str(a) for a in args)
+
+
+@patch("src.packet_log.logger")
+def test_log_meshtastic_packet(mock_logger, monkeypatch) -> None:
+    monkeypatch.setenv("LOG_PACKETS", "1")
+    log_incoming_packet(
+        IncomingPacket(
+            portnum="TEXT_MESSAGE_APP",
+            from_id="!aabbccdd",
+            to_id="!11223344",
+            channel=0,
+            has_decoded=True,
+            raw={
+                "id": 99,
+                "decoded": {
+                    "portnum": "TEXT_MESSAGE_APP",
+                    "text": "ping",
+                },
+            },
+        )
+    )
+    mock_logger.info.assert_called_once()
+    args = mock_logger.info.call_args[0]
+    assert "TEXT_MESSAGE_APP" in " ".join(str(a) for a in args)
+
+
+@patch("src.packet_log.logger")
+def test_log_skipped_when_disabled(mock_logger, monkeypatch) -> None:
+    monkeypatch.setenv("LOG_PACKETS", "false")
+    log_incoming_packet(
+        IncomingPacket(
+            portnum="MC_ACK", from_id=None, to_id=None, raw={"meshcore": True}
+        )
+    )
+    mock_logger.info.assert_not_called()


### PR DESCRIPTION
## Summary

MeshCore Phase 2.2 feeder support: device-driven channel sync, UI apply-to-radio over WebSocket, and several fixes found during staging.

Closes #104.

Related: [meshflow-api#296](https://github.com/pskillen/meshflow-api/issues/296) / [#297](https://github.com/pskillen/meshflow-api/issues/297), [meshflow-api#333](https://github.com/pskillen/meshflow-api/pull/333), [meshflow-ui#273](https://github.com/pskillen/meshflow-ui/pull/273).

### Channel sync and apply (Phase 2.2)

- On connect: read device channel table (`meshcore.commands.get_channel`) → `POST /api/meshcore/feeder/mc-channel-sync/`.
- WebSocket: handle `apply_mc_channel_config` → `set_channel` on device → re-sync to API.
- Enable `MeshflowWSClient` when `RADIO_PROTOCOL=meshcore` and storage API is configured (`MESHCORE_UPLOAD_ENABLED`).
- New modules: `src/meshcore/channels.py`, `src/meshcore/channel_sync.py`; `StorageAPI.post_mc_channel_sync()`.

### Fixes (staging)

- **Channel sync deadlock (#error2):** `sync_channels_to_api` no longer calls `run_coroutine_threadsafe` from the radio asyncio thread on connect. Uses `schedule_channel_sync()` + `sync_channels_to_api_async()` instead.
- **MC ingest JSON (#error1):** `_json_safe()` hex-encodes `bytes` in serialized MC payloads (e.g. `pkt_payload` in `rx_log_data`).
- **Bot version report (#104):** `MeshCoreRadio.local_nodenum` returns `0` (feeder placeholder) so `PUT /api/packets/0/bot-version/` succeeds; was `None` while logs showed `nodenum=0`.

### Other

- **`LOG_PACKETS`:** optional one-line MC/MT packet summaries at INFO (`LOG_PACKETS=true`, default false).
- **Tests / coverage:** channel sync, translation, storage upload, packet log, responder factory; coverage gate 80%; omit device-bound `meshcore/radio.py` / `meshtastic/radio.py` from gate (same policy as `ws_client`).
- **Docs:** `docs/MESHCORE.md` updated for channel sync, WS, nodenum, `LOG_PACKETS`.

## Background

Deploy **after** [meshflow-api#333](https://github.com/pskillen/meshflow-api/pull/333). Feeder needs `MESHCORE_UPLOAD_ENABLED`, `STORAGE_API_*`, and `MESHFLOW_WS_URL` for channel sync + apply. UI apply path requires API + bot + Redis/Channels healthy.

## Testing performed

- `pytest test/` — 195+ passed, coverage ≥ 80%
- `test/meshcore/test_channels.py`, `test_channel_sync.py`, `test_radio_channel_sync.py`
- `test/meshcore/test_storage_upload.py` (incl. `post_mc_channel_sync`)
- `test/test_bot_version_report.py` (incl. nodenum `0` for MC)
- `test/test_packet_log.py`
- Manual staging: connect, channel sync, `LOG_PACKETS`, WS apply (with API 503 when feeder offline)