### PR TITLE
feat(meshcore): feeder-scoped API URLs and pubkey header (#295)

### DIFF
--- a/docs/MESHCORE.md
+++ b/docs/MESHCORE.md
@@ -4,7 +4,7 @@
 
 **Phase 0.3 scope:** connect, receive events, translate them into the bot’s generic `RadioInterface` events, and write JSON captures under `data/meshcore_packets/<event_type>/`.
 
-**Phase 1 upload:** when `MESHCORE_UPLOAD_ENABLED=true` and `STORAGE_API_*` are set, selected events upload to `POST /api/meshcore/packets/ingest/`.
+**Phase 1 upload:** when `MESHCORE_UPLOAD_ENABLED=true` and `STORAGE_API_*` are set, selected events upload to `POST /api/meshcore/feeders/{prefix}/packets/ingest/` (12-hex pubkey prefix from `SELF_INFO`).
 
 ## Transports
 
@@ -36,7 +36,7 @@ Without `MESHCORE_UPLOAD_ENABLED`, `STORAGE_API_*` is ignored.
 
 When `MESHCORE_UPLOAD_ENABLED=true` and `STORAGE_API_*` are set, the bot also:
 
-1. **On connect** — reads the device channel table (`meshcore.commands.get_channel`) and `POST`s ` /api/meshcore/feeder/mc-channel-sync/` (device is source of truth for names/types).
+1. **On connect** — reads the device channel table (`meshcore.commands.get_channel`) and `POST`s `/api/meshcore/feeders/{prefix}/mc-channel-sync/` (device is source of truth for names/types).
 2. **WebSocket** — connects to `ws/nodes/?api_key=…` for `apply_mc_channel_config` (UI “apply to radio”); writes channels via `set_channel`, then re-syncs to the API.
 
 Traceroute commands remain Meshtastic-only; MC feeders ignore `traceroute` WS messages.
@@ -56,8 +56,9 @@ Map coordinates in the Meshflow UI require **bot** [meshflow-bot#102](https://gi
 
 MeshCore nodes are identified by **Ed25519 public keys** (64 hex chars), not Meshtastic-style 32-bit node numbers.
 
-- `MeshCoreRadio.local_node_id` is exposed as `mc:` + the first **12** hex characters of the companion’s public key after `SELF_INFO` (or `mc:unknown` if that event is missing).
-- `local_nodenum` is `0` for MeshCore feeders (matches `ManagedNode.meshtastic_node_id` on the API). Used for feeder-scoped paths such as `PUT /api/packets/0/bot-version/`. Packet ingest uses `/api/meshcore/packets/ingest/` instead.
+- `MeshCoreRadio.local_node_id` is `mc:` + the first **12** hex characters of the companion’s public key after `SELF_INFO` (or `mc:unknown` if that event is missing).
+- `feeder_mc_pubkey` (64 hex) and `feeder_mc_pubkey_prefix` (12 hex) are sent on all MeshCore API calls: URL prefix plus optional header `X-MeshCore-Feeder-Pubkey`. Configure the same full pubkey on `ManagedNode.mc_pubkey` in Django admin (see meshflow-api `docs/features/meshcore/feeder-bootstrap.md`).
+- `local_nodenum` is `None` for MeshCore; do not use `/api/packets/0/bot-version/`. Bot version uses `PUT /api/meshcore/feeders/{prefix}/bot-version/`.
 
 Remote senders in DMs use ids like `mc:p:<12-hex-prefix>` when only a short prefix is on the wire.
 

--- a/src/api/StorageAPI.py
+++ b/src/api/StorageAPI.py
@@ -4,11 +4,11 @@ Meshtastic uploads use v2 paths scoped by local nodenum:
 ``POST /api/packets/{nodenum}/ingest/`` and ``…/nodes/`` (see ``_get_url`` when
 ``api_version == 2``). v1 ``POST /api/raw-packet/`` is legacy.
 
-MeshCore uploads use ``POST /api/meshcore/packets/ingest/`` via
-:meth:`store_raw_meshcore_packet` (not the Meshtastic packet paths).
+MeshCore uploads use feeder-scoped paths:
+``POST /api/meshcore/feeders/{prefix}/packets/ingest/`` (and channel sync / bot-version).
 
-Takes a :class:`PacketSerializer` to shape outgoing data and a
-``local_meshtastic_nodenum_provider`` for Meshtastic v2 URL construction.
+Takes a :class:`PacketSerializer` to shape outgoing data, optional Meshtastic nodenum
+provider, and optional MeshCore feeder identity providers.
 """
 
 from __future__ import annotations
@@ -32,6 +32,8 @@ from src.version import get_bot_version
 
 logger = logging.getLogger(__name__)
 
+MESHCORE_FEEDER_PUBKEY_HEADER = "X-MeshCore-Feeder-Pubkey"
+
 
 class StorageAPIWrapper(BaseAPIWrapper):
     """Uploads packets and node data to a meshflow-api instance."""
@@ -47,6 +49,8 @@ class StorageAPIWrapper(BaseAPIWrapper):
         *,
         serializer: PacketSerializer,
         local_meshtastic_nodenum_provider: Callable[[], Optional[int]],
+        meshcore_feeder_prefix_provider: Optional[Callable[[], Optional[str]]] = None,
+        meshcore_feeder_pubkey_provider: Optional[Callable[[], Optional[str]]] = None,
     ):
         super().__init__(base_url, token)
         self.api_version = api_version
@@ -55,7 +59,28 @@ class StorageAPIWrapper(BaseAPIWrapper):
         )
         self._serializer = serializer
         self._local_meshtastic_nodenum_provider = local_meshtastic_nodenum_provider
+        self._meshcore_feeder_prefix_provider = meshcore_feeder_prefix_provider
+        self._meshcore_feeder_pubkey_provider = meshcore_feeder_pubkey_provider
         self._error_counter = get_global_error_counter()
+
+    def _get_headers(self) -> dict:
+        headers = super()._get_headers()
+        if self._meshcore_feeder_pubkey_provider:
+            pubkey = self._meshcore_feeder_pubkey_provider()
+            if pubkey:
+                headers[MESHCORE_FEEDER_PUBKEY_HEADER] = pubkey
+        return headers
+
+    def _meshcore_feeder_prefix(self) -> Optional[str]:
+        if not self._meshcore_feeder_prefix_provider:
+            return None
+        return self._meshcore_feeder_prefix_provider()
+
+    def _meshcore_feeder_url(self, suffix: str) -> str:
+        prefix = self._meshcore_feeder_prefix()
+        if not prefix:
+            raise ValueError("MeshCore feeder pubkey prefix not available yet")
+        return f"/api/meshcore/feeders/{prefix}/{suffix}"
 
     def _get_url(self, path: str, args: Optional[dict] = None) -> str:
         if args is None:
@@ -78,19 +103,28 @@ class StorageAPIWrapper(BaseAPIWrapper):
         return api_paths[path]
 
     def report_bot_version(self) -> bool:
-        """Report meshflow-bot version (``APP_VERSION``) to the API (v2 path only). Returns True on success."""
+        """Report meshflow-bot version to the API (v2 only). Returns True on success."""
         if self.api_version != 2:
             logger.debug(
                 "Skipping bot version report (api_version=%s)", self.api_version
             )
             return False
-        local_nodenum = self._local_meshtastic_nodenum_provider()
-        if local_nodenum is None:
-            logger.warning("Cannot report bot version: local nodenum not available yet")
-            return False
+
         version = get_bot_version()
+        prefix = self._meshcore_feeder_prefix()
+        if prefix:
+            url = self._meshcore_feeder_url("bot-version/")
+        else:
+            local_nodenum = self._local_meshtastic_nodenum_provider()
+            if local_nodenum is None:
+                logger.warning(
+                    "Cannot report bot version: nodenum and MeshCore prefix unavailable"
+                )
+                return False
+            url = self._get_url("bot_version")
+
         try:
-            self._put(self._get_url("bot_version"), json={"bot_version": version})
+            self._put(url, json={"bot_version": version})
             logger.info("Reported bot version %s to API", version)
             return True
         except HTTPError as exc:
@@ -107,7 +141,7 @@ class StorageAPIWrapper(BaseAPIWrapper):
     # --- raw packets ------------------------------------------------------
 
     def store_raw_meshcore_packet(self, packet: Any) -> Optional[dict]:
-        """Upload a MeshCore capture envelope to ``/api/meshcore/packets/ingest/``."""
+        """Upload a MeshCore capture envelope to the feeder-scoped ingest path."""
         try:
             payload = self._serializer.serialise_raw_packet(packet)
         except MeshCoreSkipUpload as exc:
@@ -120,9 +154,17 @@ class StorageAPIWrapper(BaseAPIWrapper):
             )
             return None
 
+        try:
+            url = self._meshcore_feeder_url("packets/ingest/")
+        except ValueError:
+            logger.warning(
+                "Cannot store MeshCore packet: feeder pubkey prefix not available yet"
+            )
+            return None
+
         logger.debug("Storing MeshCore packet: %s", payload.get("payload_type"))
         try:
-            response = self._post("/api/meshcore/packets/ingest/", json=payload)
+            response = self._post(url, json=payload)
             return response.json()
         except HTTPError as exc:
             self._error_counter.increment("storage.store_raw_meshcore_packet.http")
@@ -144,9 +186,16 @@ class StorageAPIWrapper(BaseAPIWrapper):
         return None
 
     def post_mc_channel_sync(self, body: dict) -> bool:
-        """POST device channel snapshot to ``/api/meshcore/feeder/mc-channel-sync/``."""
+        """POST device channel snapshot to the feeder-scoped mc-channel-sync path."""
         try:
-            response = self._post("/api/meshcore/feeder/mc-channel-sync/", json=body)
+            url = self._meshcore_feeder_url("mc-channel-sync/")
+        except ValueError:
+            logger.warning(
+                "Cannot post MC channel sync: feeder pubkey prefix not available yet"
+            )
+            return False
+        try:
+            response = self._post(url, json=body)
             return response.status_code in (200, 201)
         except HTTPError as exc:
             self._error_counter.increment("storage.post_mc_channel_sync.http")

--- a/src/main.py
+++ b/src/main.py
@@ -141,6 +141,12 @@ def main() -> None:
                 failed_packets_dir=failed_packets_dir,
                 serializer=serializer,
                 local_meshtastic_nodenum_provider=lambda: bot.my_nodenum,
+                meshcore_feeder_prefix_provider=lambda: getattr(
+                    radio, "feeder_mc_pubkey_prefix", None
+                ),
+                meshcore_feeder_pubkey_provider=lambda: getattr(
+                    radio, "feeder_mc_pubkey", None
+                ),
             )
         )
     elif STORAGE_API_ROOT and RADIO_PROTOCOL == "meshcore":
@@ -169,6 +175,12 @@ def main() -> None:
                 failed_packets_dir,
                 serializer=serializer,
                 local_meshtastic_nodenum_provider=lambda: bot.my_nodenum,
+                meshcore_feeder_prefix_provider=lambda: getattr(
+                    radio, "feeder_mc_pubkey_prefix", None
+                ),
+                meshcore_feeder_pubkey_provider=lambda: getattr(
+                    radio, "feeder_mc_pubkey", None
+                ),
             )
         )
     elif STORAGE_API_2_ROOT and RADIO_PROTOCOL == "meshcore":

--- a/src/meshcore/radio.py
+++ b/src/meshcore/radio.py
@@ -11,7 +11,6 @@ from typing import Optional
 
 from meshcore import MeshCore
 from meshcore.events import Event, EventType
-
 from src.meshcore.dump import dump_meshcore_event
 from src.meshcore.translation import (
     event_to_incoming_packet,
@@ -64,6 +63,7 @@ class MeshCoreRadio(RadioInterface):
         self._startup_error: Optional[BaseException] = None
         self._connected_once = False
         self._local_node_id: Optional[str] = None
+        self._feeder_mc_pubkey: Optional[str] = None
         self._error_counter = get_global_error_counter()
 
         self._dump_enabled = os.getenv("MESHCORE_DUMP_ENABLED", "true").lower() in (
@@ -117,9 +117,21 @@ class MeshCoreRadio(RadioInterface):
         return self._local_node_id
 
     @property
+    def feeder_mc_pubkey(self) -> Optional[str]:
+        """Full 64-char lowercase hex device pubkey after SELF_INFO."""
+        return self._feeder_mc_pubkey
+
+    @property
+    def feeder_mc_pubkey_prefix(self) -> Optional[str]:
+        """First 12 hex chars of feeder pubkey (MeshCore API URL segment)."""
+        if self._feeder_mc_pubkey and len(self._feeder_mc_pubkey) >= 12:
+            return self._feeder_mc_pubkey[:12]
+        return None
+
+    @property
     def local_nodenum(self) -> Optional[int]:
-        """Feeder nodenum for API paths that still use ``/api/packets/{id}/…`` (MC uses 0)."""
-        return 0
+        """Meshtastic-only; MeshCore uses feeder-scoped meshcore API paths."""
+        return None
 
     def send_text(
         self,
@@ -213,7 +225,14 @@ class MeshCoreRadio(RadioInterface):
             pubkey = str(self_info_evt.payload.get("public_key", "") or "")
         if not pubkey and mc.self_info:
             pubkey = str(mc.self_info.get("public_key", "") or "")
-        self._local_node_id = f"mc:{pubkey[:12]}" if pubkey else "mc:unknown"
+        pubkey_clean = pubkey.strip().lower().replace("0x", "") if pubkey else ""
+        if len(pubkey_clean) == 64:
+            int(pubkey_clean, 16)
+            self._feeder_mc_pubkey = pubkey_clean
+            self._local_node_id = f"mc:{pubkey_clean[:12]}"
+        else:
+            self._feeder_mc_pubkey = None
+            self._local_node_id = "mc:unknown" if pubkey else "mc:unknown"
 
         if not self._connected_once:
             self._connected_once = True

--- a/test/meshcore/test_storage_upload.py
+++ b/test/meshcore/test_storage_upload.py
@@ -4,22 +4,33 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from src.api.StorageAPI import StorageAPIWrapper
+from src.api.StorageAPI import MESHCORE_FEEDER_PUBKEY_HEADER, StorageAPIWrapper
 from src.meshcore.serializers import MeshCorePacketSerializer
 
+FEEDER_PREFIX = "1a37f5aea4a1"
+FEEDER_PUBKEY = FEEDER_PREFIX + ("b" * 52)
 
-def test_store_raw_meshcore_packet_posts_to_ingest() -> None:
-    wrapper = StorageAPIWrapper(
-        "http://api.test",
-        token="secret",
-        api_version=2,
-        serializer=MeshCorePacketSerializer(),
-        local_meshtastic_nodenum_provider=lambda: None,
-    )
+
+def _meshcore_wrapper(**kwargs) -> StorageAPIWrapper:
+    defaults = {
+        "base_url": "http://api.test",
+        "token": "secret",
+        "api_version": 2,
+        "serializer": MeshCorePacketSerializer(),
+        "local_meshtastic_nodenum_provider": lambda: None,
+        "meshcore_feeder_prefix_provider": lambda: FEEDER_PREFIX,
+        "meshcore_feeder_pubkey_provider": lambda: FEEDER_PUBKEY,
+    }
+    defaults.update(kwargs)
+    return StorageAPIWrapper(**defaults)
+
+
+def test_store_raw_meshcore_packet_posts_to_feeder_ingest() -> None:
+    wrapper = _meshcore_wrapper()
     envelope = {
         "meshcore": True,
         "type": "advertisement",
-        "payload": {"public_key": "a" * 64, "recv_time": 1730000000},
+        "payload": {"public_key": FEEDER_PUBKEY, "recv_time": 1730000000},
         "attributes": {},
     }
     mock_response = MagicMock()
@@ -29,18 +40,13 @@ def test_store_raw_meshcore_packet_posts_to_ingest() -> None:
     assert result["status"] == "success"
     post.assert_called_once()
     args, kwargs = post.call_args
-    assert args[0] == "/api/meshcore/packets/ingest/"
+    assert args[0] == f"/api/meshcore/feeders/{FEEDER_PREFIX}/packets/ingest/"
     assert kwargs["json"]["payload_type"] == "advert"
+    assert wrapper._get_headers()[MESHCORE_FEEDER_PUBKEY_HEADER] == FEEDER_PUBKEY
 
 
 def test_post_mc_channel_sync_success() -> None:
-    wrapper = StorageAPIWrapper(
-        "http://api.test",
-        token="secret",
-        api_version=2,
-        serializer=MeshCorePacketSerializer(),
-        local_meshtastic_nodenum_provider=lambda: None,
-    )
+    wrapper = _meshcore_wrapper()
     mock_response = MagicMock()
     mock_response.status_code = 200
     with patch.object(wrapper, "_post", return_value=mock_response) as post:
@@ -49,7 +55,7 @@ def test_post_mc_channel_sync_success() -> None:
         )
     assert ok is True
     post.assert_called_once_with(
-        "/api/meshcore/feeder/mc-channel-sync/",
+        f"/api/meshcore/feeders/{FEEDER_PREFIX}/mc-channel-sync/",
         json={"channels": [], "synced_at": "2026-01-01T00:00:00Z"},
     )
 
@@ -57,14 +63,17 @@ def test_post_mc_channel_sync_success() -> None:
 def test_post_mc_channel_sync_http_error_returns_false() -> None:
     from requests import HTTPError
 
-    wrapper = StorageAPIWrapper(
-        "http://api.test",
-        token="secret",
-        api_version=2,
-        serializer=MeshCorePacketSerializer(),
-        local_meshtastic_nodenum_provider=lambda: None,
-    )
+    wrapper = _meshcore_wrapper()
     response = MagicMock()
     response.text = "bad"
     with patch.object(wrapper, "_post", side_effect=HTTPError(response=response)):
         assert wrapper.post_mc_channel_sync({"channels": []}) is False
+
+
+def test_report_bot_version_uses_meshcore_feeder_path() -> None:
+    wrapper = _meshcore_wrapper()
+    mock_response = MagicMock()
+    with patch.object(wrapper, "_put", return_value=mock_response) as put:
+        assert wrapper.report_bot_version() is True
+    assert put.call_args[0][0] == f"/api/meshcore/feeders/{FEEDER_PREFIX}/bot-version/"
+    assert wrapper._get_headers()[MESHCORE_FEEDER_PUBKEY_HEADER] == FEEDER_PUBKEY

--- a/test/test_bot_version_report.py
+++ b/test/test_bot_version_report.py
@@ -35,19 +35,19 @@ def test_report_bot_version_puts_v2_path() -> None:
     assert put.call_args[1]["json"]["bot_version"] == get_bot_version()
 
 
-def test_report_bot_version_accepts_meshcore_feeder_nodenum_zero() -> None:
-    """MeshCore radios expose nodenum 0 for API feeder paths (not None)."""
+def test_report_bot_version_skipped_when_meshcore_prefix_missing() -> None:
+    """MeshCore must not fall back to /api/packets/0/bot-version/."""
     wrapper = StorageAPIWrapper(
         "http://api.test",
         token="secret",
         api_version=2,
         serializer=MeshtasticPacketSerializer(),
-        local_meshtastic_nodenum_provider=lambda: 0,
+        local_meshtastic_nodenum_provider=lambda: None,
+        meshcore_feeder_prefix_provider=lambda: None,
     )
-    mock_response = MagicMock()
-    with patch.object(wrapper, "_put", return_value=mock_response) as put:
-        assert wrapper.report_bot_version() is True
-    assert put.call_args[0][0] == "/api/packets/0/bot-version/"
+    with patch.object(wrapper, "_put") as put:
+        assert wrapper.report_bot_version() is False
+    put.assert_not_called()
 
 
 def test_report_bot_version_skipped_for_v1() -> None:


### PR DESCRIPTION
## Summary

- Expose `feeder_mc_pubkey` and `feeder_mc_pubkey_prefix` on `MeshCoreRadio` after `SELF_INFO`.
- `StorageAPIWrapper` uses feeder-scoped paths and sends `X-MeshCore-Feeder-Pubkey` on all MC feeder requests.
- Stops using `PUT /api/packets/0/bot-version/` for MeshCore (fixes shared-key 403).

Depends on https://github.com/pskillen/meshflow-api/pull/334 (merge/deploy API first).

References meshflow-api #295

## Testing performed

- `pytest test/meshcore/test_storage_upload.py test/test_bot_version_report.py --no-cov`
- Updated `docs/MESHCORE.md`