### PR TITLE
feat(meshcore): log device channel table on connect

### DIFF
--- a/src/meshcore/channel_sync.py
+++ b/src/meshcore/channel_sync.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Optional
 
-from src.meshcore.channels import read_device_channels, snapshot_sync_body
+from src.meshcore.channels import (
+    log_device_channels,
+    read_device_channels,
+    snapshot_sync_body,
+)
 
 if TYPE_CHECKING:
     from src.api.StorageAPI import StorageAPIWrapper
@@ -32,8 +36,20 @@ async def sync_channels_to_api_async(
             logger.exception("MeshCore read_device_channels failed: %s", exc)
             return False
 
+    log_device_channels(channels)
     body = snapshot_sync_body(channels)
-    return storage.post_mc_channel_sync(body)
+    ok = storage.post_mc_channel_sync(body)
+    if ok:
+        logger.info(
+            "MeshCore channel sync posted to API (%s channel(s))",
+            len(channels),
+        )
+    else:
+        logger.warning(
+            "MeshCore channel sync to API failed (%s channel(s) read from device)",
+            len(channels),
+        )
+    return ok
 
 
 def sync_channels_to_api(radio: "MeshCoreRadio", storage: "StorageAPIWrapper") -> bool:

--- a/src/meshcore/channels.py
+++ b/src/meshcore/channels.py
@@ -67,6 +67,29 @@ async def apply_device_channels(meshcore: MeshCore, channels: list[dict]) -> Non
             logger.warning("set_channel(%s) failed: %s", idx, evt.payload)
 
 
+def log_device_channels(channels: list[dict]) -> None:
+    """Log the device channel table at INFO (visible in docker logs on connect)."""
+    if not channels:
+        logger.info("MeshCore device channels: (none configured on device)")
+        return
+    logger.info("MeshCore device channels (%s):", len(channels))
+    for ch in sorted(channels, key=lambda c: int(c["mc_channel_idx"])):
+        idx = ch["mc_channel_idx"]
+        typ = ch.get("mc_channel_type", "?")
+        name = ch.get("name", "")
+        tag = ch.get("mc_hashtag")
+        if tag:
+            logger.info(
+                "  [%s] %s name=%r hashtag=%r",
+                idx,
+                typ,
+                name,
+                tag,
+            )
+        else:
+            logger.info("  [%s] %s name=%r", idx, typ, name)
+
+
 def snapshot_sync_body(channels: list[dict]) -> dict:
     return {
         "channels": channels,

--- a/src/meshcore/radio.py
+++ b/src/meshcore/radio.py
@@ -290,8 +290,10 @@ class MeshCoreRadio(RadioInterface):
         async def _task() -> None:
             from src.meshcore.channel_sync import sync_channels_to_api_async
 
+            logger.info("MeshCore channel sync starting")
             for storage in storage_apis:
                 await sync_channels_to_api_async(self, storage)
+            logger.info("MeshCore channel sync finished")
 
         asyncio.create_task(_task())
 

--- a/test/meshcore/test_channel_sync.py
+++ b/test/meshcore/test_channel_sync.py
@@ -50,6 +50,28 @@ def test_sync_channels_to_api_async_posts_snapshot() -> None:
     storage.post_mc_channel_sync.assert_called_once()
 
 
+def test_sync_channels_logs_and_reports_api_failure(caplog) -> None:
+    import logging
+
+    caplog.set_level(logging.INFO)
+    radio = _MeshCoreRadioStub(connected=True, meshcore=MagicMock())
+    storage = MagicMock()
+    storage.post_mc_channel_sync.return_value = False
+    channels = [{"mc_channel_idx": 0, "name": "Public", "mc_channel_type": "PUBLIC"}]
+
+    async def _run():
+        with patch(
+            "src.meshcore.channel_sync.read_device_channels",
+            new_callable=AsyncMock,
+            return_value=channels,
+        ):
+            return await sync_channels_to_api_async(radio, storage)
+
+    assert asyncio.run(_run()) is False
+    assert "MeshCore device channels (1):" in caplog.text
+    assert "channel sync to API failed" in caplog.text
+
+
 def test_sync_channels_skipped_when_disconnected() -> None:
     radio = _MeshCoreRadioStub(connected=False)
     storage = MagicMock()

--- a/test/meshcore/test_channels.py
+++ b/test/meshcore/test_channels.py
@@ -10,6 +10,7 @@ from meshcore.events import Event, EventType
 from src.meshcore.channels import (
     _channel_entry_from_info,
     apply_device_channels,
+    log_device_channels,
     read_device_channels,
     snapshot_sync_body,
 )
@@ -25,6 +26,35 @@ def test_channel_entry_hashtag():
     entry = _channel_entry_from_info(1, {"channel_name": "#galloway"})
     assert entry["mc_channel_type"] == "HASHTAG"
     assert entry["mc_hashtag"] == "galloway"
+
+
+def test_log_device_channels(caplog) -> None:
+    import logging
+
+    caplog.set_level(logging.INFO)
+    log_device_channels(
+        [
+            {"mc_channel_idx": 0, "name": "Public", "mc_channel_type": "PUBLIC"},
+            {
+                "mc_channel_idx": 1,
+                "name": "galloway",
+                "mc_channel_type": "HASHTAG",
+                "mc_hashtag": "galloway",
+            },
+        ]
+    )
+    text = caplog.text
+    assert "MeshCore device channels (2):" in text
+    assert "Public" in text
+    assert "galloway" in text
+
+
+def test_log_device_channels_empty(caplog) -> None:
+    import logging
+
+    caplog.set_level(logging.INFO)
+    log_device_channels([])
+    assert "none configured" in caplog.text
 
 
 def test_snapshot_sync_body():


### PR DESCRIPTION
## Summary

- Log MeshCore device channel table at INFO when connect triggers channel sync (PUBLIC/HASHTAG slots, names, hashtags).
- Log explicit message when no channels are read from the device.
- Log API mc-channel-sync success or failure after POST.
- Log "channel sync starting/finished" around the async task.

Helps debug staging cases where bot connects but API mirror stays empty.

## Testing performed

- `pytest test/meshcore/test_channels.py test/meshcore/test_channel_sync.py --no-cov` (17 passed)