### PR TITLE
docs(meshcore): Docker and upload env for feeders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,8 @@ MESHTASTIC_IP=192.168.123.123
 # MESHCORE_BLE_PIN=
 # MESHCORE_DEBUG=false
 # MESHCORE_DUMP_ENABLED=true
-# MESHCORE_UPLOAD_ENABLED=false
+# Set true to POST packets + mc-channel-sync (requires STORAGE_API_* below):
+# MESHCORE_UPLOAD_ENABLED=true
 
 ADMIN_NODES='!aae8900d'
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,6 +28,11 @@ services:
       # Optional: BLE instead of serial (set only one of serial or BLE)
       # - MESHCORE_BLE_ADDRESS=AA:BB:CC:DD:EE:FF
       # - MESHCORE_BLE_PIN=
+      # Upload + channel sync (see docs/MESHCORE.md and meshflow-api feeder-bootstrap.md)
+      - MESHCORE_UPLOAD_ENABLED=true
+      - STORAGE_API_ROOT=http://host.docker.internal:8000/api
+      - STORAGE_API_TOKEN=replace-me
+      - STORAGE_API_VERSION=2
       - ADMIN_NODES='!aae8900d'
     devices:
       - /dev/ttyUSB0:/dev/ttyUSB0

--- a/docs/MESHCORE.md
+++ b/docs/MESHCORE.md
@@ -62,16 +62,41 @@ MeshCore nodes are identified by **Ed25519 public keys** (64 hex chars), not Mes
 
 Remote senders in DMs use ids like `mc:p:<12-hex-prefix>` when only a short prefix is on the wire.
 
-## Running
+## Running (local)
 
 ```bash
 source venv/bin/activate
 export RADIO_PROTOCOL=meshcore
 export MESHCORE_SERIAL_DEVICE=/dev/ttyUSB0
+# Required for API upload + channel sync (Phase 1+):
+export MESHCORE_UPLOAD_ENABLED=true
+export STORAGE_API_ROOT=http://localhost:8000/api
+export STORAGE_API_TOKEN=<your Node API key>
+export STORAGE_API_VERSION=2
 python -m src.main
 ```
 
-Docker Compose: use the `meshflow-bot-meshcore` service in `docker-compose.yaml` (pass-through of `/dev/ttyUSB0` is Linux-specific; adjust the device path for your host).
+After connect, confirm logs show `POST /api/meshcore/feeders/{12-hex-prefix}/packets/ingest/` and `.../mc-channel-sync/`. Do **not** point MeshCore at `/api/packets/0/ingest/` or `/api/packets/0/bot-version/`.
+
+Operator setup (Django `ManagedNode`, `mc_pubkey`, API key): **[meshflow-api feeder bootstrap](https://github.com/pskillen/meshflow-api/blob/main/docs/features/meshcore/feeder-bootstrap.md)**.
+
+## Docker Compose
+
+Use the **`meshflow-bot-meshcore`** service in [`docker-compose.yaml`](../docker-compose.yaml). Example overrides (create `.env` beside compose or set under `environment:`):
+
+| Variable | Example | Notes |
+|----------|---------|--------|
+| `RADIO_PROTOCOL` | `meshcore` | Required |
+| `MESHCORE_SERIAL_DEVICE` | `/dev/ttyUSB0` | **Or** `MESHCORE_BLE_ADDRESS` (not both) |
+| `MESHCORE_UPLOAD_ENABLED` | `true` | Without this, `STORAGE_API_*` is ignored |
+| `STORAGE_API_ROOT` | `http://host.docker.internal:8000/api` | Reachable API base (include `/api`) |
+| `STORAGE_API_TOKEN` | `<Node API key>` | From Meshflow admin |
+| `STORAGE_API_VERSION` | `2` | Match your API |
+| `ADMIN_NODES` | `mc:deadbeefcafe` | Optional; MC admin id format may evolve |
+
+The compose file maps `/dev/ttyUSB0` into the container (Linux host). Adjust the device path or use BLE env vars on macOS/Windows. Data captures go to `./data-meshcore` → `/app/data`.
+
+**Smoke test:** with API + bot running, watch ingest logs, then in Meshflow UI open **MeshCore → Nodes** (map) and **MeshCore → Messages** after channel sync.
 
 ## Capture layout
 


### PR DESCRIPTION
## Summary

- Expand **docs/MESHCORE.md** with copy-paste local and Docker env for `MESHCORE_UPLOAD_ENABLED`, `STORAGE_API_*`, and ingest/channel-sync smoke-test steps.
- Document **meshflow-api** [feeder bootstrap](https://github.com/pskillen/meshflow-api/blob/main/docs/features/meshcore/feeder-bootstrap.md).
- Update **docker-compose.yaml** `meshflow-bot-meshcore` service with upload-related env placeholders.
- Clarify **.env.example** that upload requires `MESHCORE_UPLOAD_ENABLED=true`.

## Testing performed

- [x] Docs-only change; reviewed compose/env alignment with MESHCORE.md

Closes #112