### PR TITLE
feat(meshcore): forward path_hash_size and path_hash_mode on ingest (M1)

### DIFF
--- a/src/meshcore/serializers.py
+++ b/src/meshcore/serializers.py
@@ -79,6 +79,11 @@ def _build_from_envelope(envelope: dict[str, Any]) -> dict[str, Any]:
     payload = envelope.get("payload") or {}
     attributes = envelope.get("attributes") or {}
 
+    path_hash_size = payload.get("path_hash_size")
+    if path_hash_size is None:
+        path_hash_size = 2
+    path_hash_mode = payload.get("path_hash_mode")
+
     base: dict[str, Any] = {
         "event_type": event_type,
         "rx_time": _rx_time_from_payload(payload, attributes),
@@ -86,6 +91,8 @@ def _build_from_envelope(envelope: dict[str, Any]) -> dict[str, Any]:
         "rx_snr": payload.get("snr"),
         "route_typename": payload.get("route_typename"),
         "path_hashes": _path_hashes(payload),
+        "path_hash_size": int(path_hash_size) if path_hash_size is not None else None,
+        "path_hash_mode": int(path_hash_mode) if path_hash_mode is not None else None,
         "pkt_hash": payload.get("pkt_hash"),
         "raw": _json_safe(envelope),
     }

--- a/test/test_meshcore_path_hashes.py
+++ b/test/test_meshcore_path_hashes.py
@@ -1,6 +1,6 @@
-"""Unit tests for MeshCore path hash splitting (_path_hashes)."""
+"""Unit tests for MeshCore path hash splitting (_path_hashes) and ingest envelope."""
 
-from src.meshcore.serializers import _path_hashes
+from src.meshcore.serializers import MeshCorePacketSerializer, _path_hashes
 
 
 def test_path_hashes_two_byte_default():
@@ -26,3 +26,43 @@ def test_path_hashes_missing_path_returns_none():
 def test_path_hashes_list_passthrough():
     payload = {"path": ["aa", "bb"]}
     assert _path_hashes(payload) == ["aa", "bb"]
+
+
+def test_channel_message_envelope_includes_path_hash_size_and_mode():
+    serializer = MeshCorePacketSerializer()
+    envelope = {
+        "protocol": "meshcore",
+        "event_type": "channel_message",
+        "payload": {
+            "text": "hi",
+            "channel_idx": 0,
+            "path": "aabb",
+            "path_hash_size": 1,
+            "path_hash_mode": 2,
+            "recv_time": 1700000000.0,
+        },
+        "attributes": {},
+    }
+    result = serializer.serialise_raw_packet(envelope)
+    assert result["path_hashes"] == ["aa", "bb"]
+    assert result["path_hash_size"] == 1
+    assert result["path_hash_mode"] == 2
+
+
+def test_contact_message_envelope_defaults_path_hash_size_to_two():
+    serializer = MeshCorePacketSerializer()
+    envelope = {
+        "protocol": "meshcore",
+        "event_type": "contact_message",
+        "payload": {
+            "text": "dm",
+            "pubkey_prefix": "ab" * 6,
+            "channel_idx": 0,
+            "path": "f3bcf1",
+            "recv_time": 1700000000.0,
+        },
+        "attributes": {},
+    }
+    result = serializer.serialise_raw_packet(envelope)
+    assert result["path_hash_size"] == 2
+    assert result["path_hash_mode"] is None


### PR DESCRIPTION
## Summary

Companion to meshflow-api M1 ([#372](https://github.com/pskillen/meshflow-api/issues/372)): adds `path_hash_size` (default 2) and `path_hash_mode` to the MeshCore packet ingest envelope so the API can persist hash parameters per observation.

Related: [#119](https://github.com/pskillen/meshflow-bot/issues/119) (path_hashes), [meshflow-api#378](https://github.com/pskillen/meshflow-api/pull/378).

## Testing performed

- `pytest test/` including `test/test_meshcore_path_hashes.py`