### PR TITLE
feat(meshcore): upload rx_log_data TEXT_MSG and PATH as raw (#385)

### DIFF
--- a/docs/MESHCORE.md
+++ b/docs/MESHCORE.md
@@ -50,7 +50,8 @@ Traceroute commands remain Meshtastic-only; MC feeders ignore `traceroute` WS me
 | `advertisement` | Yes (`payload_type: advert`) | Identity only (`public_key`) |
 | **`rx_log_data`** + `payload_typename: ADVERT` | Yes | **`adv_lat` / `adv_lon` / `adv_name`** (map coordinates in Meshflow UI) |
 | `contact_message`, `channel_message` | Yes (text) | N/A |
-| `rx_log_data` (TEXT_MSG, PATH, …) | No (`MeshCoreSkipUpload`) | N/A |
+| `rx_log_data` + `TEXT_MSG` or `PATH` | Yes (`payload_type: raw`) | Path + `pkt_hash` for API twin-merge to channel messages |
+| `rx_log_data` (REQ, CONTROL, …) | No (`MeshCoreSkipUpload`) | N/A |
 
 Map coordinates in the Meshflow UI require **bot** [meshflow-bot#102](https://github.com/pskillen/meshflow-bot/issues/102) and **API** [meshflow-api#330](https://github.com/pskillen/meshflow-api/issues/330) / [#298](https://github.com/pskillen/meshflow-api/issues/298) deployed on feeders.
 

--- a/src/meshcore/serializers.py
+++ b/src/meshcore/serializers.py
@@ -11,7 +11,7 @@ from src.data_classes import MeshNode
 
 logger = logging.getLogger(__name__)
 
-UPLOADABLE_PAYLOAD_TYPES = frozenset({"advert", "channel_text", "contact_text"})
+UPLOADABLE_PAYLOAD_TYPES = frozenset({"advert", "channel_text", "contact_text", "raw"})
 
 
 def _json_safe(value: Any) -> Any:
@@ -140,7 +140,9 @@ def _build_from_envelope(envelope: dict[str, Any]) -> dict[str, Any]:
                 "adv_lat": payload.get("adv_lat"),
                 "adv_lon": payload.get("adv_lon"),
             }
-        raise MeshCoreSkipUpload(f"rx_log_data {typename} not uploaded in Phase 1")
+        if typename in ("TEXT_MSG", "PATH"):
+            return {**base, "payload_type": "raw"}
+        raise MeshCoreSkipUpload(f"rx_log_data {typename} not uploaded")
 
     raise MeshCoreSkipUpload(f"event_type {event_type!r} not uploaded in Phase 1")
 

--- a/test/meshcore/test_serializers.py
+++ b/test/meshcore/test_serializers.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from src.data_classes import MeshNode
-from src.meshcore.serializers import MeshCorePacketSerializer, MeshCoreSkipUpload
+from src.meshcore.serializers import MeshCorePacketSerializer
 
 DOCS = Path(__file__).resolve().parents[2] / "docs" / "meshcore_packets"
 
@@ -72,7 +72,7 @@ def test_serialise_contact_message() -> None:
     assert out["from_pubkey_prefix"] == "e563a2e933ce"
 
 
-def test_skip_rx_log_text() -> None:
+def test_serialise_rx_log_text_msg() -> None:
     dump = _load("rx_log_data/20260506_205845_837997.json")
     raw = {
         "meshcore": True,
@@ -80,8 +80,24 @@ def test_skip_rx_log_text() -> None:
         "payload": dump["payload"],
         "attributes": {},
     }
-    with pytest.raises(MeshCoreSkipUpload):
-        MeshCorePacketSerializer().serialise_raw_packet(raw)
+    out = MeshCorePacketSerializer().serialise_raw_packet(raw)
+    assert out["payload_type"] == "raw"
+    assert out["event_type"] == "rx_log_data"
+    assert out["pkt_hash"] == dump["payload"]["pkt_hash"]
+
+
+def test_serialise_rx_log_path() -> None:
+    dump = _load("rx_log_data/20260506_211515_351329.json")
+    raw = {
+        "meshcore": True,
+        "type": "rx_log_data",
+        "payload": dump["payload"],
+        "attributes": dump.get("attributes", {}),
+    }
+    out = MeshCorePacketSerializer().serialise_raw_packet(raw)
+    assert out["payload_type"] == "raw"
+    assert out["path_hashes"] == ["f3bcf1"]
+    assert out["path_hash_size"] == 3
 
 
 def test_rx_log_data_serialises_bytes_in_raw_payload() -> None:


### PR DESCRIPTION
## Summary

Thin bot change for meshflow-api#385: upload `rx_log_data` frames with `payload_typename` **TEXT_MSG** or **PATH** as `payload_type: raw` (forward `path`, `pkt_hash`, `path_hashes` from existing `_path_hashes()`).

## Testing performed

- `pytest test/meshcore/test_serializers.py test/test_meshcore_path_hashes.py`

## Related

- meshflow-api#385 / API PR on branch `api-385/pskillen/mc-message-path-tier1`

Part of meshflow-api#385